### PR TITLE
fix(nvidia-tuning-gke): GKE does not support setting net.ipv4.tcp_con…

### DIFF
--- a/nvidia-tuning-gke/profiles/gb200/multiNodeTraining/sysctl.conf
+++ b/nvidia-tuning-gke/profiles/gb200/multiNodeTraining/sysctl.conf
@@ -17,5 +17,4 @@ net.ipv4.tcp_rmem=4096 87380 268435456
 net.ipv4.tcp_wmem=4096 65536 268435456
 net.core.netdev_max_backlog=10000
 net.ipv4.tcp_max_syn_backlog=8192
-net.ipv4.tcp_congestion_control=bbr
 net.core.default_qdisc=fq

--- a/nvidia-tuning-gke/profiles/h100/multiNodeTraining/sysctl.conf
+++ b/nvidia-tuning-gke/profiles/h100/multiNodeTraining/sysctl.conf
@@ -11,5 +11,4 @@ net.ipv4.tcp_rmem=4096 87380 268435456
 net.ipv4.tcp_wmem=4096 65536 268435456
 net.core.netdev_max_backlog=10000
 net.ipv4.tcp_max_syn_backlog=8192
-net.ipv4.tcp_congestion_control=bbr
 net.core.default_qdisc=fq


### PR DESCRIPTION
…gestion_control for gpu nodes