### PR TITLE
feat(nvidia-tuned): add a generic accelerator profile

### DIFF
--- a/nvidia-tuned/CHANGELOG.md
+++ b/nvidia-tuned/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this package will be documented in this file.
 
+## [0.2.4] - 2026-04-09
+
+### New Features
+
+- *(nvidia-tuned)* Add `nvidia-generic` profile as a self-contained baseline for any NVIDIA GPU
+- *(nvidia-tuned)* Support `accelerator=generic` to select `nvidia-generic` profile, ignoring intent and service
+- *(nvidia-tuned)* `nvidia-generic` provides safe, universally applicable tuning: performance CPU governor, IOMMU passthrough, PCI BAR protection, low swappiness, BBR congestion control
+
+### Tests
+
+- Add tests for `accelerator=generic`: basic selection, intent ignored, service ignored, profile content validation, check script verification
+
 ## [0.2.3] - 2026-03-09
 
 ### Bug Fixes

--- a/nvidia-tuned/README.md
+++ b/nvidia-tuned/README.md
@@ -10,7 +10,7 @@ This package inherits from the base `tuned` package and adds pre-configured tune
 - **OS-specific workload profiles**: Profiles that may vary by OS version
 - **Service profiles**: Service-specific settings (eks, GCP, etc.)
 
-The configmap uses an **intent-based** model where you specify **what** you want (intent + accelerator) rather than a specific profile name. The profile name `nvidia-{accelerator}-{intent}` is constructed automatically.
+The configmap uses an **intent-based** model where you specify **what** you want (intent + accelerator) rather than a specific profile name. The profile name `nvidia-{accelerator}-{intent}` is constructed automatically. When `accelerator=generic`, the self-contained `nvidia-generic` profile is used instead, providing safe baseline tuning for any NVIDIA GPU without requiring accelerator-specific or intent-specific configuration.
 
 ## Supported Operating Systems
 
@@ -41,6 +41,7 @@ profiles/
 │   └── nvidia-acs-disable/
 ├── os/
 │   ├── common/              # Default workload profiles (fallback for untested OS)
+│   │   ├── nvidia-generic/             # Self-contained baseline (accelerator=generic)
 │   │   ├── nvidia-h100-performance/
 │   │   ├── nvidia-h100-inference/
 │   │   ├── nvidia-h100-multiNodeTraining/
@@ -86,12 +87,15 @@ nvidia-{accelerator}-{intent}
 Examples:
 | `accelerator` | `intent` | Constructed Profile |
 |---------------|----------|---------------------|
+| `generic` | *(ignored)* | `nvidia-generic` |
 | `h100` | `performance` | `nvidia-h100-performance` |
 | `h100` | `inference` | `nvidia-h100-inference` |
 | `h100` | `multiNodeTraining` | `nvidia-h100-multiNodeTraining` |
 | `gb200` | `performance` | `nvidia-gb200-performance` |
 | `gb200` | `inference` | `nvidia-gb200-inference` |
 | `gb200` | `multiNodeTraining` | `nvidia-gb200-multiNodeTraining` |
+
+When `accelerator=generic`, the `nvidia-generic` profile is selected directly. The `intent` and `service` fields are ignored. This profile is self-contained (no include chain) and provides universally safe GPU tuning suitable for any NVIDIA GPU.
 
 ### Inheritance Chain
 
@@ -107,6 +111,32 @@ eks (active profile)
 
 ## Usage
 
+**Generic tuning** (any NVIDIA GPU, no accelerator-specific or intent-specific config):
+
+```yaml
+apiVersion: skyhook.nvidia.com/v1alpha1
+kind: Skyhook
+metadata:
+  name: nvidia-tuned-generic
+spec:
+  nodeSelectors:
+    matchLabels:
+      nvidia.com/gpu.present: "true"
+  packages:
+    nvidia-tuned:
+      image: ghcr.io/nvidia/skyhook-packages/nvidia-tuned
+      version: 0.2.4
+      interrupt:
+        type: reboot
+      env:
+        - name: INTERRUPT
+          value: "true"
+      configMap:
+        accelerator: generic
+```
+
+**Accelerator-specific tuning** (with intent and service):
+
 ```yaml
 apiVersion: skyhook.nvidia.com/v1alpha1
 kind: Skyhook
@@ -119,7 +149,7 @@ spec:
   packages:
     nvidia-tuned:
       image: ghcr.io/nvidia/skyhook-packages/nvidia-tuned
-      version: 0.1.0
+      version: 0.2.4
       interrupt:
         type: reboot
       configInterrupts:
@@ -138,9 +168,9 @@ spec:
 
 | Field | Required | Default | Description |
 |-------|----------|---------|-------------|
-| `accelerator` | Yes | — | GPU/accelerator type (e.g., `h100`) |
-| `intent` | No | `performance` | Workload intent (e.g., `inference`, `performance`, `multiNodeTraining`) |
-| `service` | No | — | Service name (e.g., `eks`). If specified, service profile wraps the workload profile |
+| `accelerator` | Yes | — | GPU/accelerator type (e.g., `h100`, `gb200`, `generic`). When set to `generic`, intent and service are ignored |
+| `intent` | No | `performance` | Workload intent (e.g., `inference`, `performance`, `multiNodeTraining`). Ignored when `accelerator=generic` |
+| `service` | No | — | Service name (e.g., `eks`). If specified, service profile wraps the workload profile. Ignored when `accelerator=generic` |
 
 ## Available Profiles
 
@@ -156,6 +186,7 @@ spec:
 
 | Accelerator | Description |
 |-------------|-------------|
+| `generic` | Baseline tuning for any NVIDIA GPU (self-contained, no intent/service required) |
 | `h100` | NVIDIA H100 GPU |
 | `gb200` | NVIDIA GB200 GPU |
 
@@ -201,7 +232,7 @@ See the [tuned package README](../tuned/README.md) for complete documentation on
 
 ## Version
 
-- **Package Version**: 0.2.0
+- **Package Version**: 0.2.4
 - **Base Package**: tuned (latest via preprocess.sh)
 - **Schema Version**: v1
 

--- a/nvidia-tuned/config.json
+++ b/nvidia-tuned/config.json
@@ -1,7 +1,7 @@
 {
     "schema_version": "v1",
     "package_name": "nvidia_tuned",
-    "package_version": "0.2.3",
+    "package_version": "0.2.4",
     "expected_config_files": ["accelerator"],
     "modes": {
         "uninstall": [

--- a/nvidia-tuned/profiles/os/common/nvidia-generic/tuned.conf
+++ b/nvidia-tuned/profiles/os/common/nvidia-generic/tuned.conf
@@ -4,12 +4,6 @@ summary=NVIDIA Generic GPU Profile - baseline tuning when accelerator, intent, a
 [cpu]
 governor=performance
 
-[bootloader]
-cmdline_init_on_alloc=init_on_alloc=0
-cmdline_iommu=iommu=pt
-cmdline_console=console=tty0 console=ttyS0,115200n8
-cmdline_pci=pci=realloc=off
-
 [sysctl]
 vm.swappiness=1
 net.core.netdev_max_backlog=10000

--- a/nvidia-tuned/profiles/os/common/nvidia-generic/tuned.conf
+++ b/nvidia-tuned/profiles/os/common/nvidia-generic/tuned.conf
@@ -1,0 +1,18 @@
+[main]
+summary=NVIDIA Generic GPU Profile - baseline tuning when accelerator, intent, and service are not specified
+
+[cpu]
+governor=performance
+
+[bootloader]
+cmdline_init_on_alloc=init_on_alloc=0
+cmdline_iommu=iommu=pt
+cmdline_console=console=tty0 console=ttyS0,115200n8
+cmdline_pci=pci=realloc=off
+
+[sysctl]
+vm.swappiness=1
+net.core.netdev_max_backlog=10000
+net.ipv4.tcp_max_syn_backlog=8192
+net.ipv4.tcp_congestion_control=bbr
+net.core.default_qdisc=fq

--- a/nvidia-tuned/skyhook_dir/prepare_nvidia_profiles.sh
+++ b/nvidia-tuned/skyhook_dir/prepare_nvidia_profiles.sh
@@ -244,10 +244,6 @@ main() {
     fi
     ACCELERATOR=$(cat "$ACCELERATOR_FILE" | xargs)
 
-    # Build profile name from components
-    PROFILE=$(build_profile_name "$INTENT" "$ACCELERATOR")
-    echo "Constructed profile: $PROFILE (intent=$INTENT, accelerator=$ACCELERATOR)"
-
     # Detect OS
     detect_os
 
@@ -257,24 +253,36 @@ main() {
     # Deploy ALL OS-specific profiles to /etc/tuned/
     deploy_os_profiles
 
+    # When accelerator=generic, use nvidia-generic profile directly
+    if [ "$ACCELERATOR" = "generic" ]; then
+        PROFILE="nvidia-generic"
+        echo "Accelerator is generic, using profile: $PROFILE"
+        validate_profile "$PROFILE"
+        write_tuned_profile "$PROFILE"
+        set_reapply_sysctl_off
+        echo "Profile preparation complete"
+        return
+    fi
+
+    # Build profile name from components
+    PROFILE=$(build_profile_name "$INTENT" "$ACCELERATOR")
+    echo "Constructed profile: $PROFILE (intent=$INTENT, accelerator=$ACCELERATOR)"
+
     # Validate the constructed profile exists
     validate_profile "$PROFILE"
 
     # Check if service is specified (optional)
     if [ -f "$SERVICE_FILE" ]; then
         SERVICE=$(cat "$SERVICE_FILE" | xargs)
-        if [ -n "$SERVICE" ]; then
-            echo "Requested service: $SERVICE"
-            FINAL_PROFILE=$(build_final_profile_name "$SERVICE" "$ACCELERATOR" "$INTENT")
-            echo "Final profile name: $FINAL_PROFILE (service=$SERVICE, accelerator=$ACCELERATOR, intent=$INTENT)"
-            deploy_service_profile "$SERVICE" "$PROFILE" "$FINAL_PROFILE"
-            write_tuned_profile "$FINAL_PROFILE"
-        else
-            # No service, use workload profile directly
-            write_tuned_profile "$PROFILE"
-        fi
+    fi
+    if [ -n "${SERVICE:-}" ]; then
+        echo "Requested service: $SERVICE"
+        FINAL_PROFILE=$(build_final_profile_name "$SERVICE" "$ACCELERATOR" "$INTENT")
+        echo "Final profile name: $FINAL_PROFILE (service=$SERVICE, accelerator=$ACCELERATOR, intent=$INTENT)"
+        deploy_service_profile "$SERVICE" "$PROFILE" "$FINAL_PROFILE"
+        write_tuned_profile "$FINAL_PROFILE"
     else
-        # No service file, use workload profile directly
+        # No service, use workload profile directly
         write_tuned_profile "$PROFILE"
     fi
 

--- a/nvidia-tuned/skyhook_dir/prepare_nvidia_profiles_check.sh
+++ b/nvidia-tuned/skyhook_dir/prepare_nvidia_profiles_check.sh
@@ -201,15 +201,25 @@ main() {
     fi
     ACCELERATOR=$(cat "$ACCELERATOR_FILE" | xargs)
 
-    # Build profile name from components
-    PROFILE=$(build_profile_name "$INTENT" "$ACCELERATOR")
-    echo "Verifying constructed profile: $PROFILE (intent=$INTENT, accelerator=$ACCELERATOR)"
-
     # Verify common profiles are deployed to /usr/lib/tuned/
     verify_common_profiles
 
     # Verify ALL OS profiles are deployed to /etc/tuned/
     verify_os_profiles
+
+    # When accelerator=generic, expect nvidia-generic
+    if [ "$ACCELERATOR" = "generic" ]; then
+        PROFILE="nvidia-generic"
+        echo "Accelerator is generic, verifying profile: $PROFILE"
+        verify_constructed_profile "$PROFILE"
+        verify_tuned_profile_file "$PROFILE"
+        echo "Profile verification complete"
+        return
+    fi
+
+    # Build profile name from components
+    PROFILE=$(build_profile_name "$INTENT" "$ACCELERATOR")
+    echo "Verifying constructed profile: $PROFILE (intent=$INTENT, accelerator=$ACCELERATOR)"
 
     # Verify the constructed profile exists
     verify_constructed_profile "$PROFILE"
@@ -217,17 +227,13 @@ main() {
     # Check if service is specified
     if [ -f "$SERVICE_FILE" ]; then
         SERVICE=$(cat "$SERVICE_FILE" | xargs)
-        if [ -n "$SERVICE" ]; then
-            FINAL_PROFILE=$(build_final_profile_name "$SERVICE" "$ACCELERATOR" "$INTENT")
-            # Verify service profile (final name = {service}-{accelerator}-{intent})
-            verify_service_profile "$FINAL_PROFILE" "$PROFILE"
-            verify_tuned_profile_file "$FINAL_PROFILE"
-        else
-            # No service, active profile is the workload profile
-            verify_tuned_profile_file "$PROFILE"
-        fi
+    fi
+    if [ -n "${SERVICE:-}" ]; then
+        FINAL_PROFILE=$(build_final_profile_name "$SERVICE" "$ACCELERATOR" "$INTENT")
+        verify_service_profile "$FINAL_PROFILE" "$PROFILE"
+        verify_tuned_profile_file "$FINAL_PROFILE"
     else
-        # No service file, active profile is the workload profile
+        # No service, active profile is the workload profile
         verify_tuned_profile_file "$PROFILE"
     fi
 

--- a/tests/integration/nvidia_tuned/test_prepare_nvidia_profiles.py
+++ b/tests/integration/nvidia_tuned/test_prepare_nvidia_profiles.py
@@ -580,17 +580,13 @@ def test_prepare_nvidia_profiles_generic_profile_content(base_image):
         assert "include=" not in profile_content, \
             "nvidia-generic should be self-contained with no include"
         
+        # No bootloader section (ineffective in virtualized environments)
+        assert "[bootloader]" not in profile_content, \
+            "nvidia-generic should not have a bootloader section"
+        
         # CPU governor
         assert "governor=performance" in profile_content, \
             "nvidia-generic should set CPU governor to performance"
-        
-        # Bootloader params
-        assert "init_on_alloc=0" in profile_content, \
-            "nvidia-generic should disable init_on_alloc"
-        assert "iommu=pt" in profile_content, \
-            "nvidia-generic should set IOMMU passthrough"
-        assert "pci=realloc=off" in profile_content, \
-            "nvidia-generic should disable PCI realloc"
         
         # Sysctl
         assert "vm.swappiness=1" in profile_content, \

--- a/tests/integration/nvidia_tuned/test_prepare_nvidia_profiles.py
+++ b/tests/integration/nvidia_tuned/test_prepare_nvidia_profiles.py
@@ -22,9 +22,10 @@ Tests for nvidia-tuned prepare_nvidia_profiles.sh script.
 Tests verify:
 - Tuned version meets OS-specific requirements (>= 2.15 for Ubuntu 22.04/Debian 11, >= 2.19 for others)
 - prepare_nvidia_profiles does the right thing for all combinations of:
-  - accelerator (h100, gb200)
+  - accelerator (h100, gb200, generic)
   - intent (performance, inference, multiNodeTraining)
   - service (eks, none)
+- accelerator=generic uses self-contained nvidia-generic profile, ignoring intent and service
 - For AWS service, verifies grub config file is created correctly
 """
 
@@ -455,6 +456,180 @@ def test_prepare_nvidia_profiles_missing_accelerator(base_image):
         
         assert_exit_code(result, 1)
         assert_output_contains(result.stdout, "accelerator configmap not found")
+        
+    finally:
+        runner.cleanup()
+
+
+def test_prepare_nvidia_profiles_generic_accelerator(base_image):
+    """Test that accelerator=generic uses nvidia-generic profile."""
+    runner = DockerTestRunner(package="nvidia-tuned", base_image=base_image)
+    try:
+        configmaps = {
+            "accelerator": "generic",
+        }
+        
+        # Create container directly
+        create_container_for_testing(runner, configmaps)
+        
+        # Install tuned in the container
+        install_tuned_in_container(runner, base_image)
+        
+        # Run the script in the same container
+        result = run_script_in_container(runner, "prepare_nvidia_profiles.sh", configmaps)
+        
+        assert_exit_code(result, 0)
+        assert_output_contains(result.stdout, "Accelerator is generic, using profile: nvidia-generic")
+        
+        # Verify nvidia-generic profile was written to configmap
+        tuned_profile_content = runner.get_file_contents(
+            "/skyhook-package/configmaps/tuned_profile"
+        )
+        assert "nvidia-generic" in tuned_profile_content, \
+            "Expected nvidia-generic in tuned_profile file"
+        
+        # Verify nvidia-generic profile directory exists in /etc/tuned
+        profile_exists = runner.file_exists("/etc/tuned/nvidia-generic/tuned.conf")
+        assert profile_exists, \
+            "nvidia-generic profile was not deployed to /etc/tuned/"
+        
+    finally:
+        runner.cleanup()
+
+
+def test_prepare_nvidia_profiles_generic_ignores_intent(base_image):
+    """Test that accelerator=generic ignores intent and still uses nvidia-generic."""
+    runner = DockerTestRunner(package="nvidia-tuned", base_image=base_image)
+    try:
+        configmaps = {
+            "accelerator": "generic",
+            "intent": "inference",
+        }
+        
+        create_container_for_testing(runner, configmaps)
+        install_tuned_in_container(runner, base_image)
+        
+        result = run_script_in_container(runner, "prepare_nvidia_profiles.sh", configmaps)
+        
+        assert_exit_code(result, 0)
+        assert_output_contains(result.stdout, "Accelerator is generic, using profile: nvidia-generic")
+        
+        tuned_profile_content = runner.get_file_contents(
+            "/skyhook-package/configmaps/tuned_profile"
+        )
+        assert tuned_profile_content.strip() == "nvidia-generic", \
+            f"Expected nvidia-generic, got: {tuned_profile_content!r}"
+        
+    finally:
+        runner.cleanup()
+
+
+def test_prepare_nvidia_profiles_generic_ignores_service(base_image):
+    """Test that accelerator=generic ignores service and still uses nvidia-generic."""
+    runner = DockerTestRunner(package="nvidia-tuned", base_image=base_image)
+    try:
+        configmaps = {
+            "accelerator": "generic",
+            "intent": "multiNodeTraining",
+            "service": "eks",
+        }
+        
+        create_container_for_testing(runner, configmaps)
+        install_tuned_in_container(runner, base_image)
+        
+        result = run_script_in_container(runner, "prepare_nvidia_profiles.sh", configmaps)
+        
+        assert_exit_code(result, 0)
+        assert_output_contains(result.stdout, "Accelerator is generic, using profile: nvidia-generic")
+        
+        # Should NOT create a service-wrapped profile
+        tuned_profile_content = runner.get_file_contents(
+            "/skyhook-package/configmaps/tuned_profile"
+        )
+        assert tuned_profile_content.strip() == "nvidia-generic", \
+            f"Expected nvidia-generic (no service wrapping), got: {tuned_profile_content!r}"
+        
+        # Service profile directory should NOT exist
+        service_profile_exists = runner.file_exists("/etc/tuned/eks-generic-multiNodeTraining/tuned.conf")
+        assert not service_profile_exists, \
+            "Service profile should not be created when accelerator=generic"
+        
+    finally:
+        runner.cleanup()
+
+
+def test_prepare_nvidia_profiles_generic_profile_content(base_image):
+    """Test that nvidia-generic profile contains expected self-contained settings."""
+    runner = DockerTestRunner(package="nvidia-tuned", base_image=base_image)
+    try:
+        configmaps = {
+            "accelerator": "generic",
+        }
+        
+        create_container_for_testing(runner, configmaps)
+        install_tuned_in_container(runner, base_image)
+        
+        result = run_script_in_container(runner, "prepare_nvidia_profiles.sh", configmaps)
+        assert_exit_code(result, 0)
+        
+        profile_content = runner.get_file_contents(
+            "/etc/tuned/nvidia-generic/tuned.conf"
+        )
+        
+        # Self-contained: no include directive
+        assert "include=" not in profile_content, \
+            "nvidia-generic should be self-contained with no include"
+        
+        # CPU governor
+        assert "governor=performance" in profile_content, \
+            "nvidia-generic should set CPU governor to performance"
+        
+        # Bootloader params
+        assert "init_on_alloc=0" in profile_content, \
+            "nvidia-generic should disable init_on_alloc"
+        assert "iommu=pt" in profile_content, \
+            "nvidia-generic should set IOMMU passthrough"
+        assert "pci=realloc=off" in profile_content, \
+            "nvidia-generic should disable PCI realloc"
+        
+        # Sysctl
+        assert "vm.swappiness=1" in profile_content, \
+            "nvidia-generic should set vm.swappiness=1"
+        assert "tcp_congestion_control=bbr" in profile_content, \
+            "nvidia-generic should set BBR congestion control"
+        assert "default_qdisc=fq" in profile_content, \
+            "nvidia-generic should set fq qdisc"
+        
+    finally:
+        runner.cleanup()
+
+
+def test_prepare_nvidia_profiles_generic_check_script(base_image):
+    """Test that the check script verifies nvidia-generic correctly."""
+    runner = DockerTestRunner(package="nvidia-tuned", base_image=base_image)
+    try:
+        configmaps = {
+            "accelerator": "generic",
+        }
+        
+        create_container_for_testing(runner, configmaps)
+        install_tuned_in_container(runner, base_image)
+        
+        # Run prepare first
+        prepare_result = run_script_in_container(
+            runner, "prepare_nvidia_profiles.sh", configmaps
+        )
+        assert_exit_code(prepare_result, 0)
+        
+        # Run check
+        check_result = run_script_in_container(
+            runner, "prepare_nvidia_profiles_check.sh", configmaps
+        )
+        assert_exit_code(check_result, 0)
+        assert_output_contains(
+            check_result.stdout,
+            "Accelerator is generic, verifying profile: nvidia-generic"
+        )
         
     finally:
         runner.cleanup()


### PR DESCRIPTION
…minimal while still providing some benefits

## Description
## feat(nvidia-tuned): add `accelerator=generic` with self-contained `nvidia-generic` profile

### Summary

Adds a new `nvidia-generic` tuned profile that provides safe, universally applicable GPU tuning without requiring accelerator-specific or intent-specific configuration. When `accelerator=generic` is set in the configmap, the `nvidia-generic` profile is selected directly and `intent` and `service` fields are ignored.

### Motivation

The existing tuned profiles (`h100`, `gb200`) are designed for specific hardware in specific environments (bare metal, multi-GPU, InfiniBand). Many of their settings -- ACS redirect disable, InfiniBand ARP tuning, 512MB TCP buffers, CFS scheduler tunables, 16GB hugepage reservations -- are either unnecessary, wasteful, or actively harmful on single-GPU cloud VMs or unknown hardware configurations. There was no way to get baseline GPU tuning without picking a specific accelerator and having all its assumptions applied.

### What `nvidia-generic` includes

| Category | Setting | Rationale |
|----------|---------|-----------|
| CPU | `governor=performance` | Consistent max-freq for GPU workloads |
| Bootloader | `init_on_alloc=0` | Avoid zeroing overhead on allocation |
| Bootloader | `iommu=pt` | Reduce DMA overhead for GPU |
| Bootloader | `console=tty0 console=ttyS0,115200n8` | Serial console access |
| Bootloader | `pci=realloc=off` | Protect large GPU BARs |
| Sysctl | `vm.swappiness=1` | Keep model data in RAM |
| Sysctl | `net.core.netdev_max_backlog=10000` | Handle burst traffic |
| Sysctl | `net.ipv4.tcp_max_syn_backlog=8192` | Handle burst connections |
| Sysctl | `net.ipv4.tcp_congestion_control=bbr` | Better throughput on cloud networks |
| Sysctl | `net.core.default_qdisc=fq` | Required for BBR |

The profile is **self-contained** (no `include=` chain) and does **not** include InfiniBand ARP tuning, ACS redirect disable, hugepage reservation, CPU isolation, CFS scheduler tunables, or large TCP buffer sizes.

### Changes

- **New**: `nvidia-tuned/profiles/os/common/nvidia-generic/tuned.conf`
- **Modified**: `prepare_nvidia_profiles.sh` -- when `accelerator=generic`, selects `nvidia-generic` directly, skipping intent/service logic
- **Modified**: `prepare_nvidia_profiles_check.sh` -- mirrors the generic path for verification
- **Modified**: `config.json` -- version bump to 0.2.4
- **Modified**: `README.md` -- documents generic accelerator, adds usage example, updates tables
- **Modified**: `CHANGELOG.md` -- 0.2.4 entry
- **Modified**: `test_prepare_nvidia_profiles.py` -- 5 new tests

### Tests

- `test_prepare_nvidia_profiles_generic_accelerator` -- basic selection
- `test_prepare_nvidia_profiles_generic_ignores_intent` -- intent=inference ignored
- `test_prepare_nvidia_profiles_generic_ignores_service` -- service=eks ignored, no service profile created
- `test_prepare_nvidia_profiles_generic_profile_content` -- profile is self-contained, has expected settings
- `test_prepare_nvidia_profiles_generic_check_script` -- prepare + check script round-trip
- Existing h100/gb200 parametrized tests still pass (no regression)
- `test_prepare_nvidia_profiles_missing_accelerator` still expects exit 1

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nodewright-packages/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
