### PR TITLE
feat(copy-fail): add CVE-2026-31431 ('Copy Fail') temporary mitigation package

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,20 @@ Extends the **tuning** package with baked-in H100 and GB200 configs for GKE Cont
 - No manual sysctl.conf authoring; profile content is fixed in the image
 - See [nvidia-tuning-gke README](./nvidia-tuning-gke/README.md)
 
+### 7. Copy-Fail Package (`copy-fail/`)
+A temporary mitigation package for **CVE-2026-31431 ("Copy Fail")** that disables the vulnerable `algif_aead` kernel module.
+
+**Capabilities:**
+- Writes `/etc/modprobe.d/disable-algif.conf` to prevent `algif_aead` from loading at boot
+- Best-effort `rmmod algif_aead` for the running kernel (tolerates the module being in use)
+- Strict `config-check` that loudly fails when `algif_aead` is still loaded; opt-out via `ALLOW_LOADED_MODULE=true`
+- Clean uninstall that removes the modprobe blacklist file
+
+**Key features:**
+- Distro-agnostic (works anywhere `kmod`/`modprobe` is honored)
+- No reboot, no configmap, no interrupts — minimal surface area
+- Designed to be retired once distros ship a fixed kernel
+
 ## Package Structure
 
 Each package follows the standard NodeWright package structure:
@@ -263,6 +277,7 @@ This validation step is crucial as the agent uses JSON schema validation to ensu
 - [Tuned Package](./tuned/README.md) - Usage guide for the tuned package
 - [Kdump Package](./kdump/README.md) - Usage guide for the kdump package
 - [NVIDIA Setup Package](./nvidia-setup/README.md) - Node setup (EFA, Lustre, chrony, local disks) per service/accelerator
+- [Copy-Fail Package](./copy-fail/README.md) - CVE-2026-31431 modprobe-blacklist mitigation
 - [NVIDIA NodeWright Documentation](https://github.com/NVIDIA/skyhook) - Main NodeWright operator documentation
 
 ## Contributing

--- a/copy-fail/CHANGELOG.md
+++ b/copy-fail/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+All notable changes to this package will be documented in this file.
+
+## [1.0.0]
+
+### New Features
+
+- Initial release: temporary mitigation for CVE-2026-31431 ("Copy Fail") via modprobe blacklist of `algif_aead`.

--- a/copy-fail/Dockerfile
+++ b/copy-fail/Dockerfile
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM busybox:latest
+
+RUN mkdir -p /skyhook-package/skyhook_dir
+COPY . /skyhook-package

--- a/copy-fail/README.md
+++ b/copy-fail/README.md
@@ -27,7 +27,7 @@ Override per-node via the SCR's `env` map on the `config-check` mode.
 
 The advisory's secondary recommendation — blocking `AF_ALG` socket creation via seccomp on containerised workloads — is **not** handled by this package. That control belongs in workload manifests / runtime configuration. This package only addresses the host-level modprobe blacklist.
 
-## Example NodeWright Custom Resource
+## Example NodeWright Custom Resource, run on all nodes
 
 ```yaml
 apiVersion: skyhook.nvidia.com/v1alpha1
@@ -35,9 +35,6 @@ kind: Skyhook
 metadata:
   name: copy-fail-mitigation
 spec:
-  nodeSelectors:
-    matchLabels:
-      skyhook.nvidia.com/node-type: worker
   packages:
     copy-fail:
       version: 1.0.0
@@ -51,9 +48,20 @@ To silence the strict check on a node where the module is still loaded:
       version: 1.0.0
       image: ghcr.io/nvidia/skyhook-packages/copy-fail:1.0.0
       env:
-        config-check:
-          ALLOW_LOADED_MODULE: "true"
+        ALLOW_LOADED_MODULE: "true"
 ```
+
+### GKE ContainerOptimizedOS (or other read only filesystems)
+
+1. Install [Nodewright](https://github.com/NVIDIA/nodewright) with the following values file:
+```yaml
+controllerManager:
+  manager:
+    env:
+      copyDirRoot: /var/lib/google/nodewright # Set this to a write-able and executable directory. Does NOT need to be persistent 
+      reapplyOnReboot: "true"
+```
+
 
 ## Files written and removed
 

--- a/copy-fail/README.md
+++ b/copy-fail/README.md
@@ -38,7 +38,7 @@ spec:
   packages:
     copy-fail:
       version: 1.0.0
-      image: ghcr.io/nvidia/skyhook-packages/copy-fail:1.0.0
+      image: ghcr.io/nvidia/nodewright-packages/copy-fail
 ```
 
 To silence the strict check on a node where the module is still loaded:
@@ -46,7 +46,7 @@ To silence the strict check on a node where the module is still loaded:
 ```yaml
     copy-fail:
       version: 1.0.0
-      image: ghcr.io/nvidia/skyhook-packages/copy-fail:1.0.0
+      image: ghcr.io/nvidia/nodewright-packages/copy-fail
       env:
         ALLOW_LOADED_MODULE: "true"
 ```

--- a/copy-fail/README.md
+++ b/copy-fail/README.md
@@ -1,0 +1,76 @@
+# Copy-Fail Package
+
+This NodeWright Package applies the temporary mitigation for **CVE-2026-31431 ("Copy Fail")** as published in [CERT-EU advisory 2026-005](https://cert.europa.eu/publications/security-advisories/2026-005/).
+
+> **Temporary mitigation only.** This package is expected to be retired once distributions ship a fixed kernel. When that happens, remove the package from your SCR; the uninstall stage will clean up `/etc/modprobe.d/disable-algif.conf`.
+
+## What it does
+
+CVE-2026-31431 is a vulnerability in the Linux kernel's `algif_aead` module (the AF_ALG userspace AEAD interface). The advisory's recommended workaround is to disable the module:
+
+- `config` writes `/etc/modprobe.d/disable-algif.conf` containing `install algif_aead /bin/false`, then attempts a best-effort `rmmod algif_aead`. If the module is in use, the rmmod is skipped — the blacklist will fully take effect on the next reboot.
+- `config-check` (strict by default) verifies the blacklist file is in place AND that `algif_aead` is not currently loaded. If the file is correct but the module is still loaded, it exits non-zero with a loud message indicating the node is still vulnerable until reboot.
+- `uninstall` removes `/etc/modprobe.d/disable-algif.conf`. It does **not** proactively `modprobe algif_aead`; the kernel will autoload it on demand if anything needs it.
+- `uninstall-check` verifies the file is gone.
+
+The package does **not** force a reboot. If you need guaranteed eviction of a busy module, pair this package with a planned drain + reboot.
+
+## Tunables
+
+### `ALLOW_LOADED_MODULE` (env var on `config-check`)
+
+Default `"false"`. When `"true"`, `config-check` exits 0 even if `algif_aead` is still loaded — useful on nodes where the loaded-module case has been accepted while you wait for a planned reboot.
+
+Override per-node via the SCR's `env` map on the `config-check` mode.
+
+## Out of scope
+
+The advisory's secondary recommendation — blocking `AF_ALG` socket creation via seccomp on containerised workloads — is **not** handled by this package. That control belongs in workload manifests / runtime configuration. This package only addresses the host-level modprobe blacklist.
+
+## Example NodeWright Custom Resource
+
+```yaml
+apiVersion: skyhook.nvidia.com/v1alpha1
+kind: Skyhook
+metadata:
+  name: copy-fail-mitigation
+spec:
+  nodeSelectors:
+    matchLabels:
+      skyhook.nvidia.com/node-type: worker
+  packages:
+    copy-fail:
+      version: 1.0.0
+      image: ghcr.io/nvidia/skyhook-packages/copy-fail:1.0.0
+```
+
+To silence the strict check on a node where the module is still loaded:
+
+```yaml
+    copy-fail:
+      version: 1.0.0
+      image: ghcr.io/nvidia/skyhook-packages/copy-fail:1.0.0
+      env:
+        config-check:
+          ALLOW_LOADED_MODULE: "true"
+```
+
+## Files written and removed
+
+| Stage | File | Action |
+|---|---|---|
+| `config` | `/etc/modprobe.d/disable-algif.conf` | created (`install algif_aead /bin/false`) |
+| `config` | (kernel module) | best-effort `rmmod algif_aead` |
+| `uninstall` | `/etc/modprobe.d/disable-algif.conf` | removed |
+
+## Distribution support
+
+The package is distro-agnostic. `/etc/modprobe.d/*.conf` is honored by every mainstream Linux distribution that uses `kmod` / `modprobe`, which covers all distros listed in the advisory (Ubuntu 20.04–24.04 LTS, Amazon Linux 2023, RHEL 10.1, SUSE 16, and their kernel build family).
+
+## Retire path
+
+Once your distro ships a fixed kernel:
+
+1. Update kernels on affected nodes.
+2. Remove `copy-fail` from your SCR. The uninstall stage will remove `/etc/modprobe.d/disable-algif.conf`.
+3. The kernel will autoload `algif_aead` on demand if anything needs it.

--- a/copy-fail/config.json
+++ b/copy-fail/config.json
@@ -1,0 +1,66 @@
+{
+    "schema_version": "v1",
+    "package_name": "copy-fail",
+    "package_version": "1.0.0",
+    "expected_config_files": [],
+    "modes": {
+        "config": [
+            {
+                "name": "config",
+                "path": "config.sh",
+                "arguments": [],
+                "returncodes": [
+                    0
+                ],
+                "on_host": true,
+                "env": {},
+                "idempotence": true,
+                "upgrade_step": false
+            }
+        ],
+        "config-check": [
+            {
+                "name": "config-check",
+                "path": "config_check.sh",
+                "arguments": [],
+                "returncodes": [
+                    0
+                ],
+                "on_host": true,
+                "env": {
+                    "ALLOW_LOADED_MODULE": "false"
+                },
+                "idempotence": true,
+                "upgrade_step": false
+            }
+        ],
+        "uninstall": [
+            {
+                "name": "uninstall",
+                "path": "uninstall.sh",
+                "arguments": [],
+                "returncodes": [
+                    0
+                ],
+                "on_host": true,
+                "env": {},
+                "idempotence": true,
+                "upgrade_step": false
+            }
+        ],
+        "uninstall-check": [
+            {
+                "name": "uninstall-check",
+                "path": "uninstall_check.sh",
+                "arguments": [],
+                "returncodes": [
+                    0
+                ],
+                "on_host": true,
+                "env": {},
+                "idempotence": true,
+                "upgrade_step": false
+            }
+        ]
+    }
+}

--- a/copy-fail/skyhook_dir/config.sh
+++ b/copy-fail/skyhook_dir/config.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -15,9 +16,31 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -e
+# Apply the temporary mitigation for CVE-2026-31431 ("Copy Fail").
+# See CERT-EU advisory 2026-005:
+#   https://cert.europa.eu/publications/security-advisories/2026-005/
+#
+# Steps:
+#   1. Write a modprobe blacklist that prevents algif_aead from loading.
+#   2. Best-effort rmmod of any currently-loaded algif_aead. The module may
+#      be in use; that is acceptable here because the blacklist file is
+#      already in place for the next reboot.
 
-# Configuration script for copy-fail package
-# Mitigates CVE-2026-31431 by blacklisting algif_aead module
+set -euo pipefail
 
-exit 0
+MODPROBE_FILE="/etc/modprobe.d/disable-algif.conf"
+EXPECTED_LINE="install algif_aead /bin/false"
+
+mkdir -p /etc/modprobe.d
+
+# Write the blacklist file deterministically. Idempotent: if it already has
+# the right content, the on-disk byte sequence is identical after this line.
+printf '%s\n' "${EXPECTED_LINE}" > "${MODPROBE_FILE}"
+echo "wrote ${MODPROBE_FILE}"
+
+# Best-effort unload. Tolerate "module is in use" and "module not loaded".
+if rmmod algif_aead 2>/dev/null; then
+    echo "rmmod algif_aead: succeeded"
+else
+    echo "rmmod algif_aead: skipped (module not loaded or in use); blacklist will take effect on next reboot"
+fi

--- a/copy-fail/skyhook_dir/config.sh
+++ b/copy-fail/skyhook_dir/config.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+# Configuration script for copy-fail package
+# Mitigates CVE-2026-31431 by blacklisting algif_aead module
+
+exit 0

--- a/copy-fail/skyhook_dir/config_check.sh
+++ b/copy-fail/skyhook_dir/config_check.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+# Configuration check script for copy-fail package
+# Verifies that algif_aead module is blacklisted
+
+exit 0

--- a/copy-fail/skyhook_dir/config_check.sh
+++ b/copy-fail/skyhook_dir/config_check.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -15,9 +16,45 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -e
+# Verify the CVE-2026-31431 mitigation:
+#   1. /etc/modprobe.d/disable-algif.conf exists with the expected line.
+#   2. algif_aead is not currently loaded (strict; emits a loud failure
+#      otherwise so operators see that the node is still vulnerable until
+#      its next reboot).
+#
+# Set ALLOW_LOADED_MODULE=true to downgrade case (2) from failure to a
+# warning. Default is "false" (declared in config.json).
 
-# Configuration check script for copy-fail package
-# Verifies that algif_aead module is blacklisted
+set -euo pipefail
 
-exit 0
+MODPROBE_FILE="/etc/modprobe.d/disable-algif.conf"
+EXPECTED_LINE="install algif_aead /bin/false"
+ALLOW_LOADED_MODULE="${ALLOW_LOADED_MODULE:-false}"
+
+if [[ ! -f "${MODPROBE_FILE}" ]]; then
+    echo "ERROR: ${MODPROBE_FILE} does not exist; mitigation is not applied"
+    exit 1
+fi
+
+if ! grep -Fxq "${EXPECTED_LINE}" "${MODPROBE_FILE}"; then
+    echo "ERROR: ${MODPROBE_FILE} exists but does not contain the expected line:"
+    echo "  expected: ${EXPECTED_LINE}"
+    echo "  actual contents:"
+    sed 's/^/    /' "${MODPROBE_FILE}"
+    exit 1
+fi
+
+echo "OK: ${MODPROBE_FILE} present with expected blacklist line"
+
+if grep -q '^algif_aead ' /proc/modules; then
+    msg="algif_aead is still loaded in the running kernel; node remains vulnerable to CVE-2026-31431 until next reboot or a successful rmmod"
+    if [[ "${ALLOW_LOADED_MODULE}" == "true" ]]; then
+        echo "WARNING: ${msg} (ALLOW_LOADED_MODULE=true; exiting 0)"
+        exit 0
+    fi
+    echo "ERROR: ${msg}"
+    echo "Set ALLOW_LOADED_MODULE=true on this mode in the SCR to silence this check on nodes where the loaded-module case is accepted."
+    exit 1
+fi
+
+echo "OK: algif_aead is not loaded"

--- a/copy-fail/skyhook_dir/uninstall.sh
+++ b/copy-fail/skyhook_dir/uninstall.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -15,9 +16,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -e
+# Revert the CVE-2026-31431 mitigation by removing the modprobe blacklist
+# file. We deliberately do NOT proactively `modprobe algif_aead`: the
+# kernel will autoload it on demand if anything needs it.
 
-# Uninstall script for copy-fail package
-# Removes the algif_aead blacklist configuration
+set -euo pipefail
 
-exit 0
+MODPROBE_FILE="/etc/modprobe.d/disable-algif.conf"
+
+if [[ -f "${MODPROBE_FILE}" ]]; then
+    rm -f "${MODPROBE_FILE}"
+    echo "removed ${MODPROBE_FILE}"
+else
+    echo "${MODPROBE_FILE} not present; nothing to remove"
+fi

--- a/copy-fail/skyhook_dir/uninstall.sh
+++ b/copy-fail/skyhook_dir/uninstall.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+# Uninstall script for copy-fail package
+# Removes the algif_aead blacklist configuration
+
+exit 0

--- a/copy-fail/skyhook_dir/uninstall_check.sh
+++ b/copy-fail/skyhook_dir/uninstall_check.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+# Uninstall check script for copy-fail package
+# Verifies that the algif_aead blacklist has been removed
+
+exit 0

--- a/copy-fail/skyhook_dir/uninstall_check.sh
+++ b/copy-fail/skyhook_dir/uninstall_check.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -15,9 +16,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -e
+# Verify the modprobe blacklist file is gone.
 
-# Uninstall check script for copy-fail package
-# Verifies that the algif_aead blacklist has been removed
+set -euo pipefail
 
-exit 0
+MODPROBE_FILE="/etc/modprobe.d/disable-algif.conf"
+
+if [[ -f "${MODPROBE_FILE}" ]]; then
+    echo "ERROR: ${MODPROBE_FILE} still exists; uninstall did not complete"
+    exit 1
+fi
+
+echo "OK: ${MODPROBE_FILE} is absent"

--- a/tests/integration/copy_fail/__init__.py
+++ b/tests/integration/copy_fail/__init__.py
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Tests for copy-fail package.
+
+Test matrix: run tests against multiple base images.
+"""
+TEST_MATRIX = [
+    "ubuntu:22.04",
+    "ubuntu:24.04",
+    "rockylinux:9",
+]

--- a/tests/integration/copy_fail/test_config.py
+++ b/tests/integration/copy_fail/test_config.py
@@ -55,7 +55,7 @@ def test_config_rmmod_skipped_when_module_not_loaded(base_image):
         result = runner.run_script(script="config.sh")
 
         assert_exit_code(result, 0)
-        assert_output_contains(result.stdout, "rmmod algif_aead")
+        assert_output_contains(result.stdout, "rmmod algif_aead: skipped")
     finally:
         runner.cleanup()
 

--- a/tests/integration/copy_fail/test_config.py
+++ b/tests/integration/copy_fail/test_config.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Tests for copy-fail package config mode.
+"""
+
+from tests.helpers.assertions import (
+    assert_exit_code,
+    assert_file_contains,
+    assert_file_exists,
+    assert_output_contains,
+)
+from tests.helpers.docker_test import DockerTestRunner
+
+
+MODPROBE_FILE = "/etc/modprobe.d/disable-algif.conf"
+EXPECTED_LINE = "install algif_aead /bin/false"
+CONFIG_SH = "/skyhook-package/skyhook_dir/config.sh"
+
+
+def test_config_writes_modprobe_file(base_image):
+    """config.sh writes the modprobe blacklist file with the expected content."""
+    runner = DockerTestRunner(package="copy-fail", base_image=base_image)
+    try:
+        result = runner.run_script(script="config.sh")
+
+        assert_exit_code(result, 0)
+        assert_file_exists(runner, MODPROBE_FILE)
+        assert_file_contains(runner, MODPROBE_FILE, EXPECTED_LINE)
+        assert_output_contains(result.stdout, f"wrote {MODPROBE_FILE}")
+    finally:
+        runner.cleanup()
+
+
+def test_config_rmmod_skipped_when_module_not_loaded(base_image):
+    """In a container, algif_aead is not in /proc/modules; the rmmod branch is the 'skipped' one."""
+    runner = DockerTestRunner(package="copy-fail", base_image=base_image)
+    try:
+        result = runner.run_script(script="config.sh")
+
+        assert_exit_code(result, 0)
+        assert_output_contains(result.stdout, "rmmod algif_aead")
+    finally:
+        runner.cleanup()
+
+
+def test_config_is_idempotent(base_image):
+    """Running config.sh a second time in the same container is a no-op on the file."""
+    runner = DockerTestRunner(package="copy-fail", base_image=base_image)
+    try:
+        first = runner.run_script(script="config.sh")
+        assert_exit_code(first, 0)
+
+        second = runner.container.exec_run(["bash", CONFIG_SH])
+        assert second.exit_code == 0, second.output.decode("utf-8", errors="replace")
+
+        assert_file_exists(runner, MODPROBE_FILE)
+        assert_file_contains(runner, MODPROBE_FILE, EXPECTED_LINE)
+    finally:
+        runner.cleanup()

--- a/tests/integration/copy_fail/test_config_check.py
+++ b/tests/integration/copy_fail/test_config_check.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Tests for copy-fail package config-check mode.
+"""
+
+from tests.helpers.assertions import (
+    assert_exit_code,
+    assert_output_contains,
+)
+from tests.helpers.docker_test import DockerTestRunner
+
+
+MODPROBE_FILE = "/etc/modprobe.d/disable-algif.conf"
+CONFIG_SH = "/skyhook-package/skyhook_dir/config.sh"
+CONFIG_CHECK_SH = "/skyhook-package/skyhook_dir/config_check.sh"
+
+
+def test_check_fails_when_file_missing(base_image):
+    """config_check.sh exits non-zero when the modprobe file is absent."""
+    runner = DockerTestRunner(package="copy-fail", base_image=base_image)
+    try:
+        result = runner.run_script(script="config_check.sh")
+
+        assert_exit_code(result, 1)
+        assert_output_contains(result.stdout, "does not exist")
+        assert_output_contains(result.stdout, "mitigation is not applied")
+    finally:
+        runner.cleanup()
+
+
+def test_check_passes_after_config(base_image):
+    """After config.sh runs, config_check.sh in the same container exits 0."""
+    runner = DockerTestRunner(package="copy-fail", base_image=base_image)
+    try:
+        applied = runner.run_script(script="config.sh")
+        assert_exit_code(applied, 0)
+
+        check = runner.container.exec_run(
+            ["bash", CONFIG_CHECK_SH],
+            environment={"ALLOW_LOADED_MODULE": "false"},
+        )
+        output = check.output.decode("utf-8", errors="replace")
+        assert check.exit_code == 0, output
+        assert "OK:" in output
+    finally:
+        runner.cleanup()
+
+
+def test_check_fails_when_file_has_wrong_content(base_image):
+    """config_check.sh exits non-zero when the file exists but contents do not match."""
+    runner = DockerTestRunner(package="copy-fail", base_image=base_image)
+    try:
+        applied = runner.run_script(script="config.sh")
+        assert_exit_code(applied, 0)
+
+        # Corrupt the modprobe file out-of-band.
+        runner.container.exec_run(
+            ["sh", "-c", f"echo wrong-content > {MODPROBE_FILE}"]
+        )
+
+        check = runner.container.exec_run(["bash", CONFIG_CHECK_SH])
+        output = check.output.decode("utf-8", errors="replace")
+        assert check.exit_code == 1, output
+        assert "does not contain the expected line" in output
+    finally:
+        runner.cleanup()
+
+
+def test_check_allow_loaded_module_env_true(base_image):
+    """ALLOW_LOADED_MODULE=true keeps the check at exit 0; in-container the module is unloaded anyway."""
+    runner = DockerTestRunner(package="copy-fail", base_image=base_image)
+    try:
+        applied = runner.run_script(script="config.sh")
+        assert_exit_code(applied, 0)
+
+        check = runner.container.exec_run(
+            ["bash", CONFIG_CHECK_SH],
+            environment={"ALLOW_LOADED_MODULE": "true"},
+        )
+        output = check.output.decode("utf-8", errors="replace")
+        assert check.exit_code == 0, output
+    finally:
+        runner.cleanup()

--- a/tests/integration/copy_fail/test_uninstall.py
+++ b/tests/integration/copy_fail/test_uninstall.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Tests for copy-fail package uninstall mode.
+"""
+
+from tests.helpers.assertions import (
+    assert_exit_code,
+    assert_output_contains,
+)
+from tests.helpers.docker_test import DockerTestRunner
+
+
+MODPROBE_FILE = "/etc/modprobe.d/disable-algif.conf"
+CONFIG_SH = "/skyhook-package/skyhook_dir/config.sh"
+UNINSTALL_SH = "/skyhook-package/skyhook_dir/uninstall.sh"
+UNINSTALL_CHECK_SH = "/skyhook-package/skyhook_dir/uninstall_check.sh"
+
+
+def test_uninstall_removes_modprobe_file(base_image):
+    """uninstall.sh removes the modprobe blacklist file written by config.sh."""
+    runner = DockerTestRunner(package="copy-fail", base_image=base_image)
+    try:
+        applied = runner.run_script(script="config.sh")
+        assert_exit_code(applied, 0)
+        assert runner.file_exists(MODPROBE_FILE)
+
+        result = runner.container.exec_run(["bash", UNINSTALL_SH])
+        output = result.output.decode("utf-8", errors="replace")
+        assert result.exit_code == 0, output
+        assert not runner.file_exists(MODPROBE_FILE)
+        assert f"removed {MODPROBE_FILE}" in output
+    finally:
+        runner.cleanup()
+
+
+def test_uninstall_is_idempotent(base_image):
+    """uninstall.sh succeeds even when the file is absent."""
+    runner = DockerTestRunner(package="copy-fail", base_image=base_image)
+    try:
+        result = runner.run_script(script="uninstall.sh")
+        assert_exit_code(result, 0)
+        assert_output_contains(result.stdout, "nothing to remove")
+    finally:
+        runner.cleanup()
+
+
+def test_uninstall_check_passes_when_file_absent(base_image):
+    """uninstall_check.sh exits 0 when the file is not present."""
+    runner = DockerTestRunner(package="copy-fail", base_image=base_image)
+    try:
+        result = runner.run_script(script="uninstall_check.sh")
+        assert_exit_code(result, 0)
+        assert_output_contains(result.stdout, "OK:")
+    finally:
+        runner.cleanup()
+
+
+def test_uninstall_check_fails_when_file_present(base_image):
+    """uninstall_check.sh exits non-zero when the file still exists."""
+    runner = DockerTestRunner(package="copy-fail", base_image=base_image)
+    try:
+        applied = runner.run_script(script="config.sh")
+        assert_exit_code(applied, 0)
+
+        result = runner.container.exec_run(["bash", UNINSTALL_CHECK_SH])
+        output = result.output.decode("utf-8", errors="replace")
+        assert result.exit_code == 1, output
+        assert "still exists" in output
+        assert "uninstall did not complete" in output
+    finally:
+        runner.cleanup()


### PR DESCRIPTION
## Summary

- New standalone NodeWright package `copy-fail` that applies the temporary mitigation for **CVE-2026-31431 ("Copy Fail")** per [CERT-EU advisory 2026-005](https://cert.europa.eu/publications/security-advisories/2026-005/).
- `config` writes `/etc/modprobe.d/disable-algif.conf` (`install algif_aead /bin/false`) and best-effort unloads the running module.
- `config-check` is **strict by default** — it fails loudly if the running kernel still has `algif_aead` loaded after the mitigation file is in place. Operators can opt out per-node by setting `ALLOW_LOADED_MODULE: "true"` in the SCR's package `env`.
- `uninstall` removes the modprobe file (kernel autoloads on demand if anything needs it).
- No interrupts, no configmap, no upgrade step. Distro-agnostic. Designed to be retired once distros ship a fixed kernel.
- Integration tests under `tests/integration/copy_fail/` covering config, config-check (file-missing / wrong-content / passing / ALLOW override), and uninstall (idempotent removal + check).

Out of scope: the advisory's secondary seccomp recommendation for containerised workloads — that belongs in workload manifests, not a node package.

## Test plan

- [ ] `make validate-standalone PACKAGE=copy-fail` passes locally (verified)
- [ ] `make test-package PACKAGE=copy-fail` passes (Docker integration suite — run separately)
- [ ] CI build_container workflow succeeds on this PR
- [ ] On a test node: apply the SCR, confirm `/etc/modprobe.d/disable-algif.conf` exists with the expected line and `algif_aead` is not loaded (or, if it is, that `config-check` reports it loudly)
- [ ] Apply the `ALLOW_LOADED_MODULE: "true"` override on a busy node and confirm `config-check` now exits 0 with the warning message
- [ ] Remove the package from the SCR; confirm the modprobe file is cleaned up