### PR TITLE
nvidia-tuning-gke: drop deprecated CFS sysctls + fix base image registry + bump TUNING_VERSION to 1.1.6 + permissive CI guard

### DIFF
--- a/.github/workflows/pr_build.yaml
+++ b/.github/workflows/pr_build.yaml
@@ -106,8 +106,9 @@ jobs:
           if [ ! -f "$CONFIG_FILE" ]; then
             # Check if Dockerfile exists and has a FROM that references a skyhook-packages image
             if [ -f "$DOCKERFILE" ]; then
-              # Check if FROM line contains "skyhook-packages" (indicating it inherits from another package)
-              if grep -q "^FROM.*skyhook-packages" "$DOCKERFILE"; then
+              # Check if FROM line contains "skyhook-packages" or "nodewright-packages"
+              # (indicating it inherits from another package in this repo's published image set).
+              if grep -Eq "^FROM.*(skyhook|nodewright)-packages" "$DOCKERFILE"; then
                 echo "config_exists=false" >> $GITHUB_OUTPUT
                 echo "config_changed=false" >> $GITHUB_OUTPUT
                 echo "No config.json found, but Dockerfile inherits from skyhook-packages image - validation skipped"
@@ -152,7 +153,7 @@ jobs:
         run: |
           DOCKERFILE="${{ matrix.package }}/Dockerfile"
           
-          if [ -f "$DOCKERFILE" ] && grep -q "^FROM.*skyhook-packages" "$DOCKERFILE"; then
+          if [ -f "$DOCKERFILE" ] && grep -Eq "^FROM.*(skyhook|nodewright)-packages" "$DOCKERFILE"; then
             echo "inherits_from_skyhook_packages=true" >> $GITHUB_OUTPUT
             echo "Package inherits from skyhook-packages image - will use validate-inherited target"
           else

--- a/makefile
+++ b/makefile
@@ -108,8 +108,8 @@ validate-inherited: ## Validate an inherited package (inherits from skyhook-pack
 		echo "ERROR: Dockerfile not found for package $(PACKAGE)"; \
 		exit 1; \
 	fi
-	@if ! grep -q "^FROM.*skyhook-packages" "$(PACKAGE)/Dockerfile"; then \
-		echo "ERROR: Package $(PACKAGE) does not inherit from skyhook-packages. Use 'make validate-standalone' instead."; \
+	@if ! grep -Eq "^FROM.*(skyhook|nodewright)-packages" "$(PACKAGE)/Dockerfile"; then \
+		echo "ERROR: Package $(PACKAGE) does not inherit from skyhook-packages or nodewright-packages. Use 'make validate-standalone' instead."; \
 		exit 1; \
 	fi
 	@echo "Building container for validation: $(PACKAGE)"

--- a/nvidia-tuning-gke/Dockerfile
+++ b/nvidia-tuning-gke/Dockerfile
@@ -22,7 +22,7 @@
 #              then update_settings.sh (base tuning apply).
 
 ARG TUNING_VERSION=1.1.5
-FROM ghcr.io/nvidia/skyhook-packages/tuning:${TUNING_VERSION}
+FROM ghcr.io/nvidia/nodewright-packages/tuning:${TUNING_VERSION}
 
 COPY profiles/ /skyhook-package/profiles/
 COPY skyhook_dir/prepare_nvidia_configs.sh /skyhook-package/skyhook_dir/

--- a/nvidia-tuning-gke/Dockerfile
+++ b/nvidia-tuning-gke/Dockerfile
@@ -21,7 +21,7 @@
 # Config step: prepare_nvidia_configs.sh (populate configmaps from profile)
 #              then update_settings.sh (base tuning apply).
 
-ARG TUNING_VERSION=1.1.4
+ARG TUNING_VERSION=1.1.5
 FROM ghcr.io/nvidia/skyhook-packages/tuning:${TUNING_VERSION}
 
 COPY profiles/ /skyhook-package/profiles/

--- a/nvidia-tuning-gke/Dockerfile
+++ b/nvidia-tuning-gke/Dockerfile
@@ -21,7 +21,7 @@
 # Config step: prepare_nvidia_configs.sh (populate configmaps from profile)
 #              then update_settings.sh (base tuning apply).
 
-ARG TUNING_VERSION=1.1.5
+ARG TUNING_VERSION=1.1.6
 FROM ghcr.io/nvidia/nodewright-packages/tuning:${TUNING_VERSION}
 
 COPY profiles/ /skyhook-package/profiles/

--- a/nvidia-tuning-gke/profiles/gb200/inference/sysctl.conf
+++ b/nvidia-tuning-gke/profiles/gb200/inference/sysctl.conf
@@ -10,5 +10,3 @@ vm.max_map_count=262144
 vm.min_free_kbytes=65536
 vm.overcommit_memory=1
 vm.swappiness=1
-kernel.sched_latency_ns=1000000
-kernel.sched_min_granularity_ns=100000

--- a/nvidia-tuning-gke/profiles/h100/inference/sysctl.conf
+++ b/nvidia-tuning-gke/profiles/h100/inference/sysctl.conf
@@ -4,5 +4,3 @@ net.ipv4.conf.default.arp_announce = 2
 net.ipv4.conf.all.arp_ignore = 1
 net.ipv4.conf.default.arp_ignore = 1
 vm.swappiness=1
-kernel.sched_latency_ns=1000000
-kernel.sched_min_granularity_ns=100000

--- a/tests/integration/nvidia_tuning_gke/test_prepare_nvidia_configs.py
+++ b/tests/integration/nvidia_tuning_gke/test_prepare_nvidia_configs.py
@@ -41,7 +41,7 @@ CONFIGMAPS_DIR = "/skyhook-package/configmaps"
 @pytest.mark.parametrize(
     "accelerator,intent,expected_sysctl_line,expect_containerd",
     [
-        ("h100", "inference", "kernel.sched_latency_ns=1000000", False),
+        ("h100", "inference", "vm.swappiness=1", False),
         ("h100", "multiNodeTraining", "net.core.default_qdisc=fq", False),
         ("gb200", "inference", "vm.swappiness=1", True),
         ("gb200", "multiNodeTraining", "net.core.default_qdisc=fq", True),


### PR DESCRIPTION
## Description

Five commits on this branch, all scoped to `nvidia-tuning-gke` (one cross-cutting CI guard tweak required to keep validation passing post-rename).

### 1. `fix(nvidia-tuning-gke):` drop deprecated CFS sysctls from inference profiles

Removes two sysctl keys that no longer exist on modern kernels:

- `kernel.sched_latency_ns` — removed when EEVDF replaced CFS in Linux 6.6 (no fixed scheduling period in EEVDF).
- `kernel.sched_min_granularity_ns` — replaced by `sched_base_slice_ns` under `/sys/kernel/debug/sched/` (debugfs only, not a sysctl).

On the 6.12+ kernels shipped by GKE COS / Ubuntu node images, `sysctl -p` logs `No such file or directory` for these keys and silently ignores the values.

Files: `nvidia-tuning-gke/profiles/{gb200,h100}/inference/sysctl.conf`, plus `tests/integration/nvidia_tuning_gke/test_prepare_nvidia_configs.py` re-pointed at `vm.swappiness=1` for the h100/inference parametrized case.

### 2. `chore(nvidia-tuning-gke):` bump default `TUNING_VERSION` to 1.1.5 (superseded by commit 5)

### 3. `fix(nvidia-tuning-gke):` point `FROM` at `nodewright-packages` registry

CI publishes via `IMAGE_NAME: ${{ github.repository }}` (`pr_build.yaml:26`, `build_container.yaml:29`) consumed as `${REGISTRY}/${IMAGE_NAME}/${package_name}` (`build_package.yml:104`) → `ghcr.io/nvidia/nodewright-packages/<pkg>`. The old `skyhook-packages` path was stale and would fail to pull the base image.

```diff
-FROM ghcr.io/nvidia/skyhook-packages/tuning:${TUNING_VERSION}
+FROM ghcr.io/nvidia/nodewright-packages/tuning:${TUNING_VERSION}
```

### 4. `fix(ci):` accept `nodewright-packages` in inherited-package grep guards

Commit 3 broke CI validation. Two grep guards in `pr_build.yaml` and one in the `makefile` `validate-inherited` target keyed on the literal substring `skyhook-packages` to classify packages as inherited vs standalone. After commit 3, `nvidia-tuning-gke` no longer matched → CI flipped to `make validate-standalone`, which fails on missing step files (the inherited `update_settings_*.sh` scripts live in the base `tuning` image, not in `nvidia-tuning-gke/skyhook_dir/`).

Permissive form:

```bash
grep -Eq "^FROM.*(skyhook|nodewright)-packages"
```

Other `skyhook-packages` references in this repo (README examples, `DEVELOPER.md` docs, internal validation-image tag name, other packages' actual `FROM` lines that still resolve correctly, workflow step names) are non-behavioral and out of scope for this PR. A full repository rename belongs in a follow-up.

### 5. `chore(nvidia-tuning-gke):` bump default `TUNING_VERSION` to 1.1.6

`tuning/1.1.5` (from #45) only included the uninstall fix and shipped without the `update_settings_check.sh` fix needed for H100. That's now in `tuning/1.1.6` (#47). Bumping here so GKE picks it up; without 1.1.6, GKE deployment of the H100 inference profile still trips the production `config-check` failure.

### Scope

- GKE-only at the package level. The only cross-cutting change is the three CI/make grep guards in commit 4 — minimum needed to keep CI working for both `skyhook-packages`-rooted and `nodewright-packages`-rooted packages during the transition.
- Multi-node training profiles never had the stale CFS keys.
- AKS/EKS regression tests (`tests/integration/nvidia_tuned/test_prepare_nvidia_profiles.py`) that assert these keys are *absent* from the service profiles continue to pass.

### Merge ordering

Commit 5's `TUNING_VERSION=1.1.6` depends on #47 merging and `ghcr.io/nvidia/nodewright-packages/tuning:1.1.6` being published. Until then, container builds against this branch will fail to pull the base image. Merge order: **#47 → tuning 1.1.6 published → this PR**.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nodewright-packages/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.