### PR TITLE
feat(nvidia-setup): add bcm service that aliases kernel headers (AICR #1093)

### DIFF
--- a/nvidia-setup/CHANGELOG.md
+++ b/nvidia-setup/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this package will be documented in this file.
 
+## [Unreleased]
+
+### New Features
+
+- *(nvidia-setup)* Add `bcm` service that aliases `/usr/src/linux-$(uname -r)` to Ubuntu's `linux-headers-$(uname -r)` tree so `aicr validate` finds `.config` ([AICR #1093](https://github.com/NVIDIA/aicr/issues/1093)) by [@ayuskauskas](https://github.com/ayuskauskas)
+
 ## [0.2.2] - 2026-04-27
 
 ### Bug Fixes

--- a/nvidia-setup/README.md
+++ b/nvidia-setup/README.md
@@ -20,8 +20,10 @@ See [VERSION_OVERVIEW.md](VERSION_OVERVIEW.md) for more information about what i
 |---------|-------------|---------------------|--------------|
 | eks     | h100        | 6.14.0-1018-aws     |  1.47.0      |
 | eks     | gb200       | 6.14.0-1018-aws     |  1.47.0      |
+| bcm     | h100        | n/a                 |  n/a         |
+| bcm     | gb200       | n/a                 |  n/a         |
 
-Defaults are defined in `skyhook_dir/defaults/eks-h100.conf` and `eks-gb200.conf`. Keep this table in sync when adding or changing defaults.
+Defaults are defined in `skyhook_dir/defaults/eks-h100.conf` and `eks-gb200.conf`. The `bcm-*` defaults files are intentionally empty: the `bcm` service only runs the kernel-headers alias and does not bake in any kernel/EFA/lustre versions. Keep this table in sync when adding or changing defaults.
 
 ## Configuration
 
@@ -39,6 +41,32 @@ Set these on the package spec in the NodeWright Custom Resource (`spec.packages.
 - `NVIDIA_PIN_KERNEL` - `true` or `false` (defaults: `false`). If `true`, pin the kernel to the exact version in the package so that it will not upgrade in future.
 - `NVIDIA_KERNEL` – kernel version (overrides default from defaults file)
 - `NVIDIA_EFA` – EFA installer version
+
+## BCM Service
+
+For `service=bcm`, this package does a single thing in the apply stage: it aliases the upstream-style kernel source-tree path to Ubuntu's headers tree so that consumers (gpu-operator `nvidia-driver-daemonset`, NVIDIA DRA driver) which read `/usr/src/linux-$(uname -r)/.config` find it.
+
+On Ubuntu the file only exists at `/usr/src/linux-headers-$(uname -r)/.config`. Without this alias, `aicr validate` stalls (DRA pod `Init:0/1`, driver daemonset unhealthy). See [AICR #1093](https://github.com/NVIDIA/aicr/issues/1093).
+
+What this step does (full-directory symlink, idempotent across reboots and kernel upgrades):
+
+```
+ln -s linux-headers-$(uname -r) /usr/src/linux-$(uname -r)
+```
+
+For `service=bcm` the apply stage skips the kernel/EFA pipeline and runs only this step; `apply-check` verifies the symlink resolves. Because the script keys off `uname -r` at runtime, the alias is recreated by re-applying the package after a kernel upgrade.
+
+Example SCR fragment:
+
+```yaml
+packages:
+  nvidia-setup-bcm:
+    image: ghcr.io/nvidia/skyhook-packages/nvidia-setup
+    version: 0.3.0
+    configMap:
+      service: bcm
+      accelerator: h100
+```
 
 ## Apply Steps (EKS)
 

--- a/nvidia-setup/VERSION_OVERVIEW.md
+++ b/nvidia-setup/VERSION_OVERVIEW.md
@@ -11,3 +11,14 @@
 |---------|-------------|---------------------|-------------|--------|-------|-----|
 | eks     | h100        | 6.14.0-1018-aws     | 1.47.0      |  Y     |  Y    |  Y  |
 | eks     | gb200       | 6.14.0-1018-aws     | 1.47.0      |  Y     |  Y    |  Y  |
+
+# 0.3.x
+
+Adds the `bcm` service. `service=bcm`'s sole job is to alias `/usr/src/linux-$(uname -r)` to the Ubuntu `linux-headers-$(uname -r)` tree so consumers reading `/usr/src/linux-$(uname -r)/.config` find it (AICR #1093). For `service=bcm` the apply stage skips the kernel/EFA pipeline and runs only this single step.
+
+| service | accelerator | kernel              | efa         | chrony | raid0 | OFI | bcm headers alias |
+|---------|-------------|---------------------|-------------|--------|-------|-----|-------------------|
+| eks     | h100        | 6.14.0-1018-aws     | 1.47.0      |  Y     |  Y    |  Y  |  N                |
+| eks     | gb200       | 6.14.0-1018-aws     | 1.47.0      |  Y     |  Y    |  Y  |  N                |
+| bcm     | h100        | n/a                 | n/a         |  N     |  N    |  N  |  Y                |
+| bcm     | gb200       | n/a                 | n/a         |  N     |  N    |  N  |  Y                |

--- a/nvidia-setup/config.json
+++ b/nvidia-setup/config.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "v1",
   "package_name": "nvidia_setup",
-  "package_version": "0.2.2",
+  "package_version": "0.3.0",
   "expected_config_files": ["service", "accelerator"],
   "modes": {
     "apply": [

--- a/nvidia-setup/skyhook_dir/apply.sh
+++ b/nvidia-setup/skyhook_dir/apply.sh
@@ -25,6 +25,13 @@ STEPS_DIR="${SKYHOOK_DIR}/skyhook_dir/steps"
 NVIDIA_SETUP_INSTALL_KERNEL="${NVIDIA_SETUP_INSTALL_KERNEL:-false}"
 export NVIDIA_SETUP_INSTALL_KERNEL SKYHOOK_DIR
 
+# service=bcm's only job is to alias the kernel-headers tree (AICR #1093).
+# Skip the kernel/EFA pipeline entirely.
+if [ "${SERVICE}" = "bcm" ]; then
+  "${STEPS_DIR}/setup_bcm_kernel_headers.sh"
+  exit 0
+fi
+
 # If only installing kernel: run ensure_kernel (which installs and may reboot) and exit
 if [ "${NVIDIA_SETUP_INSTALL_KERNEL}" = "true" ]; then
   "${STEPS_DIR}/ensure_kernel.sh"

--- a/nvidia-setup/skyhook_dir/apply_check.sh
+++ b/nvidia-setup/skyhook_dir/apply_check.sh
@@ -22,6 +22,12 @@ STEPS_CHECK_DIR="${SKYHOOK_DIR}/skyhook_dir/steps_check"
 # shellcheck source=load_defaults.sh
 . "${SKYHOOK_DIR}/skyhook_dir/load_defaults.sh"
 
+# service=bcm's only job is to alias the kernel-headers tree (AICR #1093).
+if [ "${SERVICE}" = "bcm" ]; then
+  "${STEPS_CHECK_DIR}/setup_bcm_kernel_headers_check.sh"
+  exit 0
+fi
+
 # Skip checks if only installing kernel as we need to reboot before any check would work
 if [ "${NVIDIA_SETUP_INSTALL_KERNEL}" = "true" ]; then
   exit 0

--- a/nvidia-setup/skyhook_dir/defaults/bcm-gb200.conf
+++ b/nvidia-setup/skyhook_dir/defaults/bcm-gb200.conf
@@ -1,0 +1,2 @@
+# BCM + GB200: bcm service only does the kernel-headers alias (AICR #1093);
+# no kernel/EFA/lustre versions are baked in here.

--- a/nvidia-setup/skyhook_dir/defaults/bcm-h100.conf
+++ b/nvidia-setup/skyhook_dir/defaults/bcm-h100.conf
@@ -1,0 +1,2 @@
+# BCM + H100: bcm service only does the kernel-headers alias (AICR #1093);
+# no kernel/EFA/lustre versions are baked in here.

--- a/nvidia-setup/skyhook_dir/steps/setup_bcm_kernel_headers.sh
+++ b/nvidia-setup/skyhook_dir/steps/setup_bcm_kernel_headers.sh
@@ -45,7 +45,7 @@ fi
 # source tree (Debian linux-source or hand-built) and removing it is not safe.
 if [ -e "${LINK_PATH}" ] && [ ! -L "${LINK_PATH}" ]; then
   echo "ERROR: ${LINK_PATH} exists and is not a symlink; refusing to replace it" >&2
-  exit 1
+  exit 0
 fi
 
 # Stale or wrong symlink — replace it with the correct one.

--- a/nvidia-setup/skyhook_dir/steps/setup_bcm_kernel_headers.sh
+++ b/nvidia-setup/skyhook_dir/steps/setup_bcm_kernel_headers.sh
@@ -44,7 +44,7 @@ fi
 # Refuse to clobber a real directory at LINK_PATH — that would be a real kernel
 # source tree (Debian linux-source or hand-built) and removing it is not safe.
 if [ -e "${LINK_PATH}" ] && [ ! -L "${LINK_PATH}" ]; then
-  echo "ERROR: ${LINK_PATH} exists and is not a symlink; refusing to replace it" >&2
+  echo "WARNING: ${LINK_PATH} exists and is not a symlink; refusing to replace it" >&2
   exit 0
 fi
 

--- a/nvidia-setup/skyhook_dir/steps/setup_bcm_kernel_headers.sh
+++ b/nvidia-setup/skyhook_dir/steps/setup_bcm_kernel_headers.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Alias the upstream-style kernel source tree to Ubuntu's linux-headers tree so
+# consumers (gpu-operator nvidia-driver-daemonset, NVIDIA DRA driver) that read
+# /usr/src/linux-$(uname -r)/.config find it.
+#
+# On Ubuntu the file only exists at /usr/src/linux-headers-$(uname -r)/.config.
+# See https://github.com/NVIDIA/aicr/issues/1093.
+
+set -euo pipefail
+
+KERNEL_RELEASE="$(uname -r)"
+HEADERS_NAME="linux-headers-${KERNEL_RELEASE}"
+HEADERS_PATH="/usr/src/${HEADERS_NAME}"
+LINK_PATH="/usr/src/linux-${KERNEL_RELEASE}"
+
+if [ ! -d "${HEADERS_PATH}" ]; then
+  echo "ERROR: ${HEADERS_PATH} does not exist; install linux-headers-${KERNEL_RELEASE} first" >&2
+  exit 1
+fi
+
+# Already correct: a symlink whose target matches HEADERS_NAME. Idempotent re-run.
+if [ -L "${LINK_PATH}" ] && [ "$(readlink "${LINK_PATH}")" = "${HEADERS_NAME}" ]; then
+  echo "OK: ${LINK_PATH} already points to ${HEADERS_NAME}"
+  exit 0
+fi
+
+# Refuse to clobber a real directory at LINK_PATH — that would be a real kernel
+# source tree (Debian linux-source or hand-built) and removing it is not safe.
+if [ -e "${LINK_PATH}" ] && [ ! -L "${LINK_PATH}" ]; then
+  echo "ERROR: ${LINK_PATH} exists and is not a symlink; refusing to replace it" >&2
+  exit 1
+fi
+
+# Stale or wrong symlink — replace it with the correct one.
+ln -sfn "${HEADERS_NAME}" "${LINK_PATH}"
+echo "linked ${LINK_PATH} -> ${HEADERS_NAME}"

--- a/nvidia-setup/skyhook_dir/steps_check/setup_bcm_kernel_headers_check.sh
+++ b/nvidia-setup/skyhook_dir/steps_check/setup_bcm_kernel_headers_check.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Verify the BCM/Ubuntu kernel-headers alias is in place for the running kernel.
+# See setup_bcm_kernel_headers.sh and https://github.com/NVIDIA/aicr/issues/1093.
+
+set -euo pipefail
+
+KERNEL_RELEASE="$(uname -r)"
+LINK_PATH="/usr/src/linux-${KERNEL_RELEASE}"
+CONFIG_PATH="${LINK_PATH}/.config"
+
+if [ ! -e "${LINK_PATH}" ]; then
+  echo "ERROR: ${LINK_PATH} does not exist" >&2
+  exit 1
+fi
+
+if [ ! -e "${CONFIG_PATH}" ]; then
+  echo "ERROR: ${CONFIG_PATH} does not resolve" >&2
+  exit 1
+fi
+
+echo "OK: ${CONFIG_PATH} resolves"


### PR DESCRIPTION
## Summary

- Adds a new `bcm` service to the `nvidia-setup` package that creates a full-directory symlink `/usr/src/linux-$(uname -r)` -> `linux-headers-$(uname -r)` so consumers (gpu-operator `nvidia-driver-daemonset`, NVIDIA DRA driver) which read `/usr/src/linux-$(uname -r)/.config` find it on Ubuntu. Replaces the manual `pdsh` hardlink workaround in [AICR #1093](https://github.com/NVIDIA/aicr/issues/1093) and survives reboot / kernel upgrade.
- For `service=bcm` the apply stage skips the kernel/EFA pipeline entirely and runs only this single step; `apply-check` verifies the symlink resolves.
- Cross-cutting across `bcm-*` accelerator combinations: ships `bcm-h100` and `bcm-gb200` defaults (intentionally empty — bcm uses no kernel/EFA/lustre versions).
- Bumps `nvidia-setup` `0.2.2` → `0.3.0`.

Closes NVIDIA/aicr#1093.

## Test plan

- [ ] Build the package image from this branch
- [ ] Apply on a BCM/Ubuntu node with `configMap: { service: bcm, accelerator: h100 }` and confirm `/usr/src/linux-$(uname -r)/.config` resolves
- [ ] Run `aicr validate --phase deployment` and `--phase conformance` end-to-end: `nvidia-driver-daemonset` clean, DRA pod reaches `Running` (no `Init:0/1` stall), health checks green
- [ ] Re-apply after a kernel upgrade and verify the alias is recreated for the new running kernel
- [ ] Sanity: existing `eks-h100` / `eks-gb200` apply paths are unchanged