### PR TITLE
ci(general): add issue triage + PR path-labeler automation and package labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report_form.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_form.yml
@@ -34,6 +34,21 @@ body:
     validations:
       required: true
 
+  - type: dropdown
+    id: package
+    attributes:
+      label: Which package does this relate to?
+      options:
+        - shellscript
+        - tuning
+        - tuned
+        - kdump
+        - nvidia-setup
+        - nvidia-tuned
+        - nvidia-tuning-gke
+        - copy-fail
+        - General / multiple packages
+
   - type: input
     id: package-version
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request_form.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request_form.yml
@@ -60,6 +60,7 @@ body:
         - nvidia-setup
         - nvidia-tuned
         - nvidia-tuning-gke
+        - copy-fail
         - New package request
         - General / multiple packages
 

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,82 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Path-based PR labels for actions/labeler. Kept in sync with the package/*
+# label family in .github/labels.yml and the triage keyword maps in
+# .github/workflows/triage.yaml.
+#
+# One label per package directory. Packages are independent top-level dirs, so a
+# simple '<package>/**' glob per label is unambiguous (e.g. 'tuned/**' does not
+# match 'nvidia-tuned/**').
+
+package/copy-fail:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'copy-fail/**'
+
+package/kdump:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'kdump/**'
+
+package/nvidia-setup:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'nvidia-setup/**'
+
+package/nvidia-tuned:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'nvidia-tuned/**'
+
+package/nvidia-tuning-gke:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'nvidia-tuning-gke/**'
+
+package/shellscript:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'shellscript/**'
+
+package/tuned:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'tuned/**'
+
+package/tuning:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'tuning/**'
+
+component/ci:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '.github/**'
+          - 'scripts/**'
+          - '**/[Mm]akefile'
+          - '**/*.mk'
+
+tests:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'tests/**'
+
+doc:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'docs/**'
+          - '**/*.md'

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -99,3 +99,56 @@
 - name: "do-not-merge"
   color: "b60205"
   description: "PR should not be merged in its current state"
+
+# ── Triage ───────────────────────────────────────────────────────────────────
+# Applied on issue open by .github/workflows/triage.yaml, removed once a routing
+# label (package/*, component/ci, or doc) lands.
+
+- name: "needs-triage"
+  color: "ededed"
+  description: "New issue awaiting triage. Removed once a routing label is applied."
+
+# ── Package / Area ────────────────────────────────────────────────────────────
+# Which package or area an issue/PR touches. Applied by triage (issues) and by
+# the path labeler (PRs); see .github/workflows/triage.yaml, .github/labeler.yml.
+# One label per package directory; packages release independently.
+
+- name: "package/copy-fail"
+  color: "1d76db"
+  description: "Relates to the copy-fail package"
+
+- name: "package/kdump"
+  color: "1d76db"
+  description: "Relates to the kdump package"
+
+- name: "package/nvidia-setup"
+  color: "1d76db"
+  description: "Relates to the nvidia-setup package"
+
+- name: "package/nvidia-tuned"
+  color: "1d76db"
+  description: "Relates to the nvidia-tuned package"
+
+- name: "package/nvidia-tuning-gke"
+  color: "1d76db"
+  description: "Relates to the nvidia-tuning-gke package"
+
+- name: "package/shellscript"
+  color: "1d76db"
+  description: "Relates to the shellscript package"
+
+- name: "package/tuned"
+  color: "1d76db"
+  description: "Relates to the tuned package"
+
+- name: "package/tuning"
+  color: "1d76db"
+  description: "Relates to the tuning package"
+
+- name: "component/ci"
+  color: "5319e7"
+  description: "CI, GitHub Actions, repo tooling and scripts"
+
+- name: "tests"
+  color: "fef2c0"
+  description: "Relates to the test suite (tests/)"

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Auto-Label PRs
+
+# Labels PRs by changed path (see .github/labeler.yml).
+#
+# pull_request_target runs with a repo-scoped token even for fork PRs. This is
+# safe here because the job never checks out or executes PR code: actions/labeler
+# only reads the changed-file list through the API.
+
+on:
+  pull_request_target:
+    types: [opened, synchronize]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+
+  label:
+    name: Label PRs by path
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    timeout-minutes: 5
+    steps:
+      - name: Label by path
+        uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213  # v6.1.0
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          sync-labels: true

--- a/.github/workflows/triage.yaml
+++ b/.github/workflows/triage.yaml
@@ -1,0 +1,223 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Issue Triage
+
+# Auto-triages incoming issues: stamps needs-triage on open, infers a package/*
+# label from the issue-form package dropdown (then conventional-commit scope, then
+# package-name keywords), and clears needs-triage once a routing label lands.
+#
+# Keep the package list here in sync with .github/labels.yml, .github/labeler.yml,
+# and the package dropdowns in .github/ISSUE_TEMPLATE/*.
+
+on:
+  issues:
+    types: [opened, labeled]
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+# Serialize per issue so a rapid open->label sequence doesn't race on the
+# needs-triage label. Don't cancel: every event must finish its labeling.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+
+  triage:
+    name: Auto-Triage Issues
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    timeout-minutes: 5
+    steps:
+      - name: Add needs-triage on new issue
+        if: github.event.action == 'opened'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+        with:
+          script: |
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: ['needs-triage'],
+            });
+
+      - name: Infer package label on new issue
+        if: github.event.action == 'opened'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+        with:
+          script: |
+            const title = context.payload.issue.title || '';
+            const body = context.payload.issue.body || '';
+            const existingLabels = new Set((context.payload.issue.labels || []).map(label => label.name));
+
+            // The package directories, longest names first so a substring match
+            // (e.g. "tuned" inside "nvidia-tuned") never beats the specific one.
+            const PACKAGES = [
+              'nvidia-tuning-gke',
+              'nvidia-tuned',
+              'nvidia-setup',
+              'copy-fail',
+              'shellscript',
+              'kdump',
+              'tuned',
+              'tuning',
+            ];
+
+            // Conventional-commit scope tokens -> label. Package scopes map to
+            // their package label; cross-cutting scopes map to area labels.
+            const scopeMap = new Map([
+              ...PACKAGES.map(pkg => [pkg, `package/${pkg}`]),
+              ['general', 'component/ci'],
+              ['ci', 'component/ci'],
+              ['actions', 'component/ci'],
+              ['workflow', 'component/ci'],
+              ['workflows', 'component/ci'],
+              ['tooling', 'component/ci'],
+              ['doc', 'doc'],
+              ['docs', 'doc'],
+              ['readme', 'doc'],
+              ['test', 'tests'],
+              ['tests', 'tests'],
+            ]);
+
+            function normalize(value) {
+              return value.trim().toLowerCase();
+            }
+
+            // Sentinel dropdown values that don't map to a single package; ignore
+            // them and fall back to scope/keyword inference.
+            const AMBIGUOUS = ['new package request', 'general / multiple packages', '_no response_', 'none'];
+
+            // The issue forms render the package dropdown as a "### Which package
+            // does this relate to?" heading followed by the chosen value.
+            function inferFromDropdown() {
+              const match = body.match(/^#{2,3}\s+Which package does this relate to\?\s*$[\r\n]+(?:[\r\n]*)([^\r\n]+)/im);
+              if (!match) {
+                return null;
+              }
+              const value = normalize(match[1]);
+              if (!value || AMBIGUOUS.includes(value)) {
+                return null;
+              }
+              return PACKAGES.includes(value) ? `package/${value}` : null;
+            }
+
+            // Conventional-commit scope in the title, e.g. "fix(kdump): ...".
+            function inferFromScope() {
+              const scopeMatch = title.toLowerCase().match(/^[a-z]+\(([^)]+)\):/);
+              if (!scopeMatch) {
+                return null;
+              }
+              // Scope may be "general/ci" etc.; try the whole scope then each token.
+              const scope = scopeMatch[1].trim();
+              if (scopeMap.has(scope)) {
+                return scopeMap.get(scope);
+              }
+              for (const token of scope.split(/[^a-z0-9-]+/)) {
+                if (scopeMap.has(token)) {
+                  return scopeMap.get(token);
+                }
+              }
+              return null;
+            }
+
+            // Keyword match against package names only (most specific first).
+            function inferFromText(text) {
+              const normalized = text.toLowerCase();
+              for (const pkg of PACKAGES) {
+                const re = new RegExp(`\\b${pkg}\\b`);
+                if (re.test(normalized)) {
+                  return `package/${pkg}`;
+                }
+              }
+              return null;
+            }
+
+            const ROUTING = label => label.startsWith('package/') || ['doc', 'component/ci', 'tests'].includes(label);
+            const labels = new Set([...existingLabels].filter(ROUTING));
+
+            // Only infer when the reporter gave us no routing label already.
+            if (labels.size === 0) {
+              const inferred = inferFromDropdown() || inferFromScope() || inferFromText(title) || inferFromText(body);
+              if (inferred) {
+                labels.add(inferred);
+              }
+            }
+
+            if (labels.size === 0) {
+              core.info('No package label inferred for this issue');
+              return;
+            }
+
+            const toAdd = [...labels].filter(label => !existingLabels.has(label));
+            if (toAdd.length > 0) {
+              core.info(`Adding labels: ${toAdd.join(', ')}`);
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                labels: toAdd,
+              });
+            } else {
+              core.info('Issue already has all inferred labels');
+            }
+
+            try {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                name: 'needs-triage',
+              });
+              core.info('Removed needs-triage after routing label assignment');
+            } catch (error) {
+              if (error.status === 404) {
+                core.info('needs-triage label not present');
+                return;
+              }
+              throw error;
+            }
+
+      # Only a routing decision (package/*, doc, or component/ci) counts as
+      # triaged. Automated labels like lifecycle/stale must NOT clear needs-triage.
+      - name: Remove needs-triage when triaged
+        if: >-
+          github.event.action == 'labeled' &&
+          (startsWith(github.event.label.name, 'package/') ||
+           github.event.label.name == 'doc' ||
+           github.event.label.name == 'component/ci' ||
+           github.event.label.name == 'tests')
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+        with:
+          script: |
+            const { data: labels } = await github.rest.issues.listLabelsOnIssue({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            if (labels.some(l => l.name === 'needs-triage')) {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                name: 'needs-triage',
+              });
+            }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,27 @@ This repo does **not** contain the operator, the agent, or any Go code. It is sh
 └── skyhook_dir/        # lifecycle scripts and static files the scripts use
 ```
 
+## Adding a new package
+
+A package becomes "real" to CI once its directory has a `Dockerfile`. Beyond the
+package contents themselves, a few repo-wide places track the package set and must
+be updated in the same change, or its label automation silently goes stale:
+
+- `.github/labels.yml`: add a `package/<name>` label (same color family as the
+  others). Run `make labels` to sync it to GitHub.
+- `.github/labeler.yml`: add a `package/<name>` entry mapping `<name>/**` so PRs
+  touching the package get labeled.
+- `.github/ISSUE_TEMPLATE/bug_report_form.yml` and `feature_request_form.yml`: add
+  `<name>` to the "Which package does this relate to?" dropdown so reporters can
+  select it.
+- `.github/workflows/triage.yaml`: add `<name>` to the `PACKAGES` list (keep the
+  longest-name-first ordering so substring names like `tuned` don't shadow
+  `nvidia-tuned`).
+
+Keep these four in sync with each other; the dropdown value, the label suffix, the
+labeler glob directory, and the triage `PACKAGES` entry are all the same package
+directory name.
+
 ## How packages work (the contract you must not break)
 
 - Everything under `/skyhook-package` in the image lands at `${SKYHOOK_DIR}` on the host. `skyhook_dir/` lands at `${STEP_ROOT}`. `root_dir/` is laid down at `/`.
@@ -86,6 +107,23 @@ Almost all package logic is bash. The existing scripts are not yet consistent (s
 - **On tag push `<package>/<version>`:** two independent workflows run. `build_container.yaml` builds and pushes the multi-arch image (`linux/amd64,linux/arm64`) with a build-provenance attestation; `release.yml` creates the GitHub Release with `git-cliff` notes scoped to that package. The image build (here and in `pr_build.yaml`) goes through the `.github/actions/build-package` composite action. (`build_package.yml` is a reusable `workflow_call` workflow that exists but is not currently wired up.)
 - **Published image path:** `ghcr.io/nvidia/skyhook-packages/<package>:<version>` (the `skyhook-packages` segment is retained pending the rename).
 - An optional `<package>/preprocess.sh` is run before the image build and can emit `BUILD_ARGS`.
+
+## Keeping software current
+
+Prefer the latest stable versions of the software this repo depends on, and keep
+them moving forward rather than letting them drift. This covers base images in
+`Dockerfile`s, the tools the lifecycle scripts invoke, the Python deps under
+`tests/`, and the `uses:` actions in workflows. Staying current is how we pick up
+upstream security and bug fixes.
+
+Balance "latest" against reproducibility and supply-chain safety:
+
+- **Pin GitHub Actions to a commit SHA** with the human-readable version in a
+  trailing comment (e.g. `actions/labeler@f27b...e213  # v6.1.0`). To update, bump
+  the SHA and the comment together; do not float a `@v6` tag.
+- When you touch a file that references a pinned action, a base image tag, or a
+  tool version, check whether a newer stable release exists and update it if the
+  bump is safe. Treat a stale pin you are already editing as worth refreshing.
 
 ## Gotchas
 


### PR DESCRIPTION
## Summary

Ports the issue/PR-management automation from [`NVIDIA/nodewright`](https://github.com/NVIDIA/nodewright) (issue #260), adapted for this per-package monorepo. Part of #54. Closes #55, #56, #57.

The operator repo's `component/*` scheme doesn't map to this repo (independently built/versioned packages, each a top-level dir), so this uses a per-package `package/*` scheme and drops the Go/Helm-specific bits.

### What's included
- **Labels (#55)** — `labels.yml`: `needs-triage`, 8 `package/*` labels, `component/ci`, `tests`. No `size/*` (nodewright's real labeler is path-only). Sync with `make labels`.
- **Labeler (#57)** — `.github/labeler.yml` maps each package dir + `component/ci` + `tests` + `doc` to a label; `.github/workflows/labeler.yaml` runs `actions/labeler` (pinned v6.1.0) on `pull_request_target` opened/synchronize with `sync-labels`. The job never checks out or runs PR code, so the elevated token is safe.
- **Triage (#56)** — `.github/workflows/triage.yaml`: stamps `needs-triage` on open; infers a `package/*` label by precedence (issue-form package dropdown → conventional-commit scope → package-name keyword); clears `needs-triage` once a routing label (`package/*`, `doc`, `component/ci`, `tests`) lands. `workflow_dispatch`, per-issue concurrency, `actions/github-script` pinned v9.0.0.
- **Issue templates (#56)** — added a "Which package does this relate to?" dropdown to the bug template (the feature template already had one); added `copy-fail` to both so every `package/*` label is reachable from the form.
- **AGENTS.md** — a new-package setup checklist (keep `labels.yml`, `labeler.yml`, both dropdowns, and the triage `PACKAGES` list in sync) and a "keep software current" policy (prefer latest stable; pin actions to a SHA + version comment).

### Design decisions
Per-package labels (packages release independently); size labeling dropped to match the real source; package dropdown added to the bug template for reliable triage. Captured in the linked issues.

## Test Plan

GitHub-config / docs change (no package code).
- [x] `actionlint` clean on `triage.yaml` and `labeler.yaml`.
- [x] All YAML parses (`yq`); `labels.yml` loads via `sync_labels.py`.
- [x] **9/9 unit tests** of the *actual* extracted triage inference script: dropdown wins, sentinel dropdown falls through to scope, specific package beats generic substring (`nvidia-tuned` not `tuned`), `general/ci` scope → `component/ci`, and `needs-triage` removal on routing-label assignment.
- [x] Every label referenced by `labeler.yml` is defined in `labels.yml`.
- [ ] After merge: run `make labels` to sync the new labels to GitHub, then confirm triage on a fresh test issue and labeler on a test PR.

## Notes
- `make labels` (label sync to GitHub) is intentionally a separate, manually-run step; this PR only defines the labels.

## Checklist
- [x] My commits are signed off (`git commit -s`) per the DCO.
- [ ] New or existing tests cover these changes. (GitHub-config/docs only; triage logic unit-tested locally)
- [x] The documentation is up to date with these changes.