### PR TITLE
ci(general): add welcome, lock-threads, and inactive-pr-reminder workflows

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -16,9 +16,6 @@
 
 blank_issues_enabled: false
 contact_links:
-  - name: Ask a question
-    url: https://github.com/NVIDIA/nodewright-packages/discussions
-    about: Ask questions and get help from the community via GitHub Discussions.
   - name: Report a security vulnerability
     url: https://github.com/NVIDIA/nodewright-packages/security/advisories/new
     about: Please report security vulnerabilities privately. Do not open a public issue.

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Question / Get Help
+description: Ask a question about using the NodeWright packages
+title: "[QUESTION]: "
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        We don't use GitHub Discussions, so questions are tracked as issues.
+        Before opening one, please check the [README](https://github.com/NVIDIA/nodewright-packages/blob/main/README.md),
+        the per-package READMEs, and the [Contributing Guide](https://github.com/NVIDIA/nodewright-packages/blob/main/CONTRIBUTING.md).
+
+  - type: textarea
+    id: question
+    attributes:
+      label: What's your question?
+      placeholder: How do I configure the crashkernel size for the kdump package?
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: What have you tried, and what are you trying to accomplish? Include the package and version if relevant.
+
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/NVIDIA/nodewright-packages/blob/main/CODE_OF_CONDUCT.md)
+      options:
+        - label: I agree to follow the project's Code of Conduct
+          required: true
+        - label: I have searched existing issues and have found no duplicates for this question
+          required: true

--- a/.github/workflows/inactive-pr-reminder.yaml
+++ b/.github/workflows/inactive-pr-reminder.yaml
@@ -1,0 +1,90 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Inactive PR Reminder
+
+# Nudges PRs idle 14-29 days, the window before stale.yaml marks PRs stale at 30,
+# so authors get a reminder before the stale bot fires. The fork guard keeps the
+# scheduled job from running on forks.
+
+on:
+  schedule:
+    - cron: '0 7 * * *'  # daily at 07:00 UTC
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}
+
+jobs:
+
+  remind:
+    name: Nudge Inactive PRs
+    if: github.repository == 'NVIDIA/nodewright-packages'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    timeout-minutes: 10
+    steps:
+      - name: Check for inactive PRs
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+        with:
+          script: |
+            const now = new Date();
+            const msPerDay = 86400000;
+            const skipLabels = ['lifecycle/frozen', 'do-not-merge'];
+
+            const prs = await github.paginate(github.rest.pulls.list, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              sort: 'updated',
+              direction: 'asc',
+              per_page: 100,
+            });
+
+            for (const pr of prs) {
+              // Skip PRs explicitly held open or parked.
+              if (pr.labels.some(l => skipLabels.includes(l.name))) continue;
+
+              const updated = new Date(pr.updated_at);
+              const daysInactive = Math.floor((now - updated) / msPerDay);
+
+              // Target the 14-29 day window, before the stale bot fires at 30.
+              if (daysInactive < 14 || daysInactive >= 30) continue;
+
+              // Don't double-remind: skip if a bot already left a reminder.
+              // Paginate so an earlier reminder past page 1 still counts.
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                per_page: 100,
+              });
+              const alreadyReminded = comments.some(c =>
+                c.user.type === 'Bot' && c.body.includes('inactive for')
+              );
+              if (alreadyReminded) continue;
+
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                body: `@${pr.user.login} this PR has been inactive for ${daysInactive} days. Do you need help finishing it, or should we close it for now? Feel free to reopen anytime.`,
+              });
+            }

--- a/.github/workflows/lock-threads.yaml
+++ b/.github/workflows/lock-threads.yaml
@@ -1,0 +1,109 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Lock Stale Threads
+
+# Locks issues and PRs that have been closed for 90+ days, leaving a comment
+# explaining how to re-engage. Complements stale.yaml (stale -> close); lock runs
+# after close. The fork guard keeps the scheduled job from running on forks.
+
+on:
+  schedule:
+    - cron: '0 6 * * *'  # daily at 06:00 UTC
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}
+
+jobs:
+
+  lock:
+    name: Lock Closed Threads
+    if: github.repository == 'NVIDIA/nodewright-packages'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    timeout-minutes: 10
+    steps:
+      - name: Lock stale closed issues and PRs
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+        with:
+          script: |
+            const now = new Date();
+            const msPerDay = 86400000;
+            const inactiveDays = 90;
+
+            // Lock stale closed issues.
+            const issues = await github.paginate(github.rest.issues.listForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'closed',
+              sort: 'updated',
+              direction: 'asc',
+              per_page: 100,
+            });
+
+            for (const issue of issues) {
+              if (issue.locked || issue.pull_request) continue;
+              const updated = new Date(issue.updated_at);
+              if ((now - updated) / msPerDay < inactiveDays) continue;
+
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body: 'This issue has been automatically locked since it has been closed for 90 days with no further activity. Please open a new issue for related concerns.',
+              });
+              await github.rest.issues.lock({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                lock_reason: 'resolved',
+              });
+            }
+
+            // Lock stale closed PRs.
+            const prs = await github.paginate(github.rest.pulls.list, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'closed',
+              sort: 'updated',
+              direction: 'asc',
+              per_page: 100,
+            });
+
+            for (const pr of prs) {
+              if (pr.locked) continue;
+              const updated = new Date(pr.updated_at);
+              if ((now - updated) / msPerDay < inactiveDays) continue;
+
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                body: 'This pull request has been automatically locked since it has been closed for 90 days with no further activity. Please open a new pull request for related changes.',
+              });
+              await github.rest.issues.lock({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                lock_reason: 'resolved',
+              });
+            }

--- a/.github/workflows/welcome.yaml
+++ b/.github/workflows/welcome.yaml
@@ -1,0 +1,98 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Welcome First-Time Contributors
+
+on:
+  issues:
+    types: [opened]
+  pull_request_target:
+    types: [opened]
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.issue.number || github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+
+  welcome:
+    name: Welcome New Contributor
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    timeout-minutes: 5
+    steps:
+      - name: Welcome First-Time Issue Author
+        if: github.event_name == 'issues'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+        with:
+          script: |
+            const creator = context.payload.issue.user.login;
+            const { data: { total_count } } = await github.rest.search.issuesAndPullRequests({
+              q: `repo:${context.repo.owner}/${context.repo.repo} type:issue author:${creator}`,
+            });
+
+            // Only greet on the very first issue this author has opened here.
+            if (total_count === 1) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: [
+                  `Welcome to NodeWright, @${creator}! Thanks for opening your first issue.`,
+                  '',
+                  'A maintainer will triage this shortly. In the meantime:',
+                  `- Check the [Contributing Guide](https://github.com/${context.repo.owner}/${context.repo.repo}/blob/main/CONTRIBUTING.md) for project conventions`,
+                  `- If you have not already, the [issue templates](https://github.com/${context.repo.owner}/${context.repo.repo}/issues/new/choose) help us route and triage faster`,
+                  `- Browse existing [labels](https://github.com/${context.repo.owner}/${context.repo.repo}/labels) for related topics`,
+                ].join('\n'),
+              });
+            }
+
+      - name: Welcome First-Time PR Author
+        if: github.event_name == 'pull_request_target'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+        with:
+          script: |
+            const creator = context.payload.pull_request.user.login;
+            const { data: { total_count } } = await github.rest.search.issuesAndPullRequests({
+              q: `repo:${context.repo.owner}/${context.repo.repo} type:pr author:${creator}`,
+            });
+
+            // Only greet on the very first PR this author has opened here.
+            if (total_count === 1) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                body: [
+                  `Welcome to NodeWright, @${creator}! Thanks for your first pull request.`,
+                  '',
+                  'Before review, please ensure:',
+                  `- All commits are signed off per the [DCO](https://github.com/${context.repo.owner}/${context.repo.repo}/blob/main/CONTRIBUTING.md) (\`git commit -s\`)`,
+                  '- Commits follow [Conventional Commits](https://www.conventionalcommits.org/) with the package name as scope',
+                  '- CI checks pass (tests, lint)',
+                  '- The PR description explains the *why* behind your changes',
+                  '',
+                  'A maintainer will review this soon.',
+                ].join('\n'),
+              });
+            }


### PR DESCRIPTION
## Summary

Ports the remaining community-automation workflows from [`NVIDIA/nodewright`](https://github.com/NVIDIA/nodewright) (issue #260), adapted for this repo. Part of #54. Closes #58, #59, #60.

| Workflow | Issue | Trigger | Behavior |
|----------|-------|---------|----------|
| `welcome.yaml` | #58 | `issues`/`pull_request_target` opened | Greets a contributor's first issue and first PR (once each). |
| `lock-threads.yaml` | #59 | daily cron 06:00 UTC | Locks issues/PRs closed 90+ days with an explanatory comment. |
| `inactive-pr-reminder.yaml` | #60 | daily cron 07:00 UTC | Nudges PRs idle 14-29 days, once per PR. |

### Adaptations from the source
- **Discussions disabled here.** The welcome greeting drops the Discussions link and points to `CONTRIBUTING.md`, the issue templates, and labels. As part of the same premise, this also removes the now-dead "Ask a question → Discussions" contact link from `.github/ISSUE_TEMPLATE/config.yml` and adds a **`question.yml`** issue template so questions open an issue instead.
- **Fork guards** on both cron workflows use `github.repository == 'NVIDIA/nodewright-packages'` so they no-op on forks.
- **Reminder window aligns with `stale.yaml`:** PRs go stale at 30 days, so the 14-29 day nudge fires strictly before that.
- All three keep `workflow_dispatch`, carry the Apache SPDX header (matching `stale.yaml`), and pin `actions/github-script` to `v9.0.0`.

### Safety
`welcome.yaml` uses `pull_request_target` so it can comment on fork PRs, but never checks out or executes PR code (it only reads `context.payload` and calls REST APIs); permissions are least-privilege and scoped per job.

## Test Plan

GitHub-config change (no package code).
- [x] `actionlint` clean on all three workflows.
- [x] All four embedded `github-script` bodies pass `node --check`.
- [x] `config.yml` and `question.yml` parse (`yq`); no dead Discussions links remain.
- [x] Reviewed via `superpowers:code-reviewer` (APPROVE, no critical/important issues): boundary math (14-29, lock 90), dedupe substring match, `pull_request_target` safety, fork guards, pins, and SPDX headers all verified.
- [ ] After merge: confirm welcome on a test issue/PR, and `workflow_dispatch` the two cron jobs once to sanity-check.

## Checklist
- [x] My commits are signed off (`git commit -s`) per the DCO.
- [ ] New or existing tests cover these changes. (GitHub-config only; embedded JS syntax-checked, logic reviewed)
- [x] The documentation is up to date with these changes.