### PR TITLE
docs(general): add AUTHORS and SUPPORT.md

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,4 @@
+# Ordered by name
+Alex Yuskauskas <ayuskauskas@nvidia.com> https://github.com/ayuskauskas https://github.com/vistorve
+Brian Lockwood <blockwood@nvidia.com> https://github.com/lockwobr
+Riley Rice <riceriley59@gmail.com> https://github.com/rice-riley

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,31 @@
+<!--
+  SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+# Support
+
+## Support Level: Maintained
+
+NodeWright Packages (formerly Skyhook Packages) is actively maintained by NVIDIA. We welcome bug reports, feature requests, and community contributions.
+
+## Getting Help
+
+- **Bug Reports**: [File a bug report](https://github.com/NVIDIA/nodewright-packages/issues/new?template=bug_report_form.yml)
+- **Feature Requests**: [Request a feature](https://github.com/NVIDIA/nodewright-packages/issues/new?template=feature_request_form.yml)
+- **Questions**: [Ask a question](https://github.com/NVIDIA/nodewright-packages/issues/new?template=question.yml)
+- **Documentation**: [Request new documentation](https://github.com/NVIDIA/nodewright-packages/issues/new?template=documentation_request_new.yml) or [report a documentation problem](https://github.com/NVIDIA/nodewright-packages/issues/new?template=documentation_request_correction.yml)
+- **Security Issues**: Please report via [NVIDIA's Security Vulnerability Form](https://www.nvidia.com/object/submit-security-vulnerability.html). Do **not** file public GitHub issues for security vulnerabilities. See [SECURITY.md](SECURITY.md) for details.
+
+## What to Expect
+
+- Issues are triaged on a best-effort basis.
+- Critical bugs and security vulnerabilities are prioritized.
+- Community contributions via pull requests are reviewed by maintainers.
+
+## Documentation
+
+- [Project README](README.md)
+- [Developer Guide](DEVELOPER.md)
+- [Contributing Guide](CONTRIBUTING.md)
+- [Package Lifecycle](PACKAGE_LIFECYCLE.md)


### PR DESCRIPTION
## Summary

Add two standard project docs from the repo-hygiene epic (#54).

- **`AUTHORS`** (closes #64): the project authors, taken from the operator repo's `AUTHORS` and trimmed to the contributors relevant here.
- **`SUPPORT.md`** (closes #65): adapted from the operator repo's `SUPPORT.md` for this repo.

## SUPPORT.md adaptations

- **Questions** point at this repo's `question.yml` issue template, since GitHub Discussions is disabled here (the operator linked Discussions).
- Added a **Documentation** line pointing at this repo's two documentation issue templates.
- Bug and feature links point at this repo's templates; new-issue URLs use the canonical `NVIDIA/nodewright-packages`.
- The Documentation section links this repo's real root docs (`README.md`, `PACKAGE_LIFECYCLE.md`, `DEVELOPER.md`, `CONTRIBUTING.md`) instead of the operator's cli/versioning/release-process docs.
- The `KnownIssues.md` link is intentionally omitted because that file does not exist yet (tracked separately as #68); it can be added when that lands.
- Security guidance (NVIDIA Security Vulnerability Form + `SECURITY.md`) is kept.

## Closes

- Closes #64
- Closes #65
- Part of #54
