### PR TITLE
ci(general): add ci-gate aggregator check for branch protection

### DIFF
--- a/.github/workflows/pr_build.yaml
+++ b/.github/workflows/pr_build.yaml
@@ -317,3 +317,25 @@ jobs:
             echo "❌ Some packages failed to build"
             exit 1
           fi
+
+  # Single required status check for branch protection (see #78). This always
+  # runs on every PR and passes only when each upstream job either succeeded or
+  # was legitimately skipped (no package changed, so the matrix jobs do not
+  # run). Branch protection requires this one stable check name instead of the
+  # matrix jobs, which skip per-PR and would otherwise leave a required check
+  # stuck "pending" forever. `commitlint` is required separately since it always
+  # runs and reports on its own.
+  ci-gate:
+    name: ci-gate
+    needs: [detect-changes, validate, test, build]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    steps:
+      - name: Verify required jobs passed
+        run: |
+          results='${{ toJSON(needs) }}'
+          printf '%s\n' "$results"
+          # Pass when every upstream job is success or skipped; fail on any
+          # failure or cancellation.
+          echo "$results" | jq -e 'to_entries | all(.value.result == "success" or .value.result == "skipped")'


### PR DESCRIPTION
## Summary

Add a single `ci-gate` status check so branch protection can block merging to `main` until it is safe (closes #78, part of #54).

`main` is currently unprotected. The matrix jobs in `pr_build.yaml` (`validate`/`test`/`build`) **skip** when no package changed, so they cannot be marked required directly: a skipped required check leaves a PR stuck "pending" forever. This adds a `ci-gate` job that:

- `needs: [detect-changes, validate, test, build]`, `if: always()`, so it always runs and reports on every PR to `main`.
- Passes only when every upstream job is `success` or `skipped`, and fails on any `failure`/`cancelled` (`jq -e 'to_entries | all(...)'`).

So a PR with a failing validate/test/build fails `ci-gate`, while a PR that changes no package (matrix jobs skipped) resolves to success rather than blocking.

## Rollout (after this merges)

This PR only lands the check; it does not enable protection (so it does not block the in-flight PRs). Once this is on `main`:

1. **Verify the gate live first:** open a throwaway PR that breaks a `config.json` and confirm `ci-gate` fails; open a docs-only PR and confirm `ci-gate` passes while the matrix jobs skip.
2. **Enable branch protection** requiring `ci-gate` + `commitlint` (both always run and report). Do NOT require the matrix job names (`validate`/`test`/`build`), or no-change PRs will wedge.

```bash
gh api -X PUT repos/NVIDIA/skyhook-packages/branches/main/protection --input - <<'JSON'
{
  "required_status_checks": { "strict": true, "contexts": ["ci-gate", "commitlint"] },
  "enforce_admins": false,
  "required_pull_request_reviews": null,
  "restrictions": null
}
JSON
```

`shellcheck` is intentionally excluded from the required set until it is green (#69), and is path-filtered so it would wedge docs-only PRs if required. `security-checkov` (#62) joins later on the same basis.

## Open decisions (branch protection)

- Require a minimum number of PR review approvals? (currently none)
- `enforce_admins`? (currently false)
- `strict` (require branch up to date before merge) is set to true.

## Closes

- Closes #78
- Part of #54
