### PR TITLE
ci: add CodeQL static analysis workflow

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# CodeQL static analysis for the Python sources (tests/) and the GitHub Actions
+# workflows. Runs weekly and on demand. The package payloads are shell, which
+# CodeQL does not analyze; shellcheck covers those (see lint-shellcheck.yaml).
+
+name: "CodeQL"
+
+on:
+  schedule:
+    - cron: '0 5 * * 1'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: python
+            build-mode: none
+          - language: actions
+            build-mode: none
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9  # v4.37.0
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+      - uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9  # v4.37.0
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## What

Adds a weekly (and `workflow_dispatch`) CodeQL scan over the repo's CodeQL-supported surfaces:

- **Python** — `tests/`
- **Actions** — the GitHub Actions workflows themselves

## Why

Adds code-level SAST to complement the existing shellcheck linting. Mirror of the CodeQL workflow being added to the operator repo.

## Design notes

- **Shell is intentionally excluded**: CodeQL does not analyze shell, and the package payloads are shell scripts. Those are already covered by `lint-shellcheck.yaml`, noted in a comment so nobody "fixes" the omission.
- `build-mode: none` for both languages (neither needs a compile step).
- Matrix per language with `fail-fast: false`.
- `codeql-action` pinned by SHA (v4.37.0); `checkout@v4` matches the repo's existing usage.

One of a set of community/CI-hygiene additions being ported from other NVIDIA OSS repos.