### PR TITLE
fix(general/ci): prevent shell injection in release workflow

### DIFF
--- a/.github/workflows/build_container.yaml
+++ b/.github/workflows/build_container.yaml
@@ -53,6 +53,10 @@ jobs:
           REF_NAME: ${{ github.ref_name }}
         run: |
           PACKAGE_NAME="${REF_NAME%%/*}"
+          if ! [[ "${PACKAGE_NAME}" =~ ^[a-z][a-z0-9-]*$ ]]; then
+            echo "ERROR: package component '${PACKAGE_NAME}' must match [a-z][a-z0-9-]* (lowercase letters, digits, hyphens only)" >&2
+            exit 1
+          fi
           echo "package_name=${PACKAGE_NAME}" >> $GITHUB_OUTPUT
 
       - name: Build and push Docker image

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,6 +54,10 @@ jobs:
         id: extract
         run: |
           PACKAGE_NAME=$(echo "${GITHUB_REF_NAME}" | cut -f 1 -d /)
+          if ! [[ "${PACKAGE_NAME}" =~ ^[a-z][a-z0-9-]*$ ]]; then
+            echo "ERROR: package component '${PACKAGE_NAME}' must match [a-z][a-z0-9-]* (lowercase letters, digits, hyphens only)" >&2
+            exit 1
+          fi
           echo "package_name=${PACKAGE_NAME}" >> "$GITHUB_OUTPUT"
 
       # git-cliff release assets are versioned in the filename
@@ -154,6 +158,10 @@ jobs:
             PRERELEASE_FLAG="--prerelease"
           else
             echo "ERROR: tag '${GITHUB_REF_NAME}' does not match <package>/<MAJOR>.<MINOR>.<PATCH> or <package>/<MAJOR>.<MINOR>.<PATCH>-rc.<N>" >&2
+            exit 1
+          fi
+          if ! git check-ref-format "${GITHUB_REF_NAME}"; then
+            echo "ERROR: '${GITHUB_REF_NAME}' is not a valid git ref name" >&2
             exit 1
           fi
           if ! gh release view "${GITHUB_REF_NAME}" >/dev/null 2>&1; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Extract package name from tag
         id: extract
         run: |
-          PACKAGE_NAME=$(echo "${{ github.ref_name }}" | cut -f 1 -d /)
+          PACKAGE_NAME=$(echo "${GITHUB_REF_NAME}" | cut -f 1 -d /)
           echo "package_name=${PACKAGE_NAME}" >> "$GITHUB_OUTPUT"
 
       # git-cliff release assets are versioned in the filename
@@ -81,9 +81,9 @@ jobs:
       # panic), matching the committed CHANGELOGs.
       # --strip all removes the changelog header/footer, leaving just the body.
       - name: Generate release notes
-        id: release_notes
+        env:
+          PACKAGE: ${{ steps.extract.outputs.package_name }}
         run: |
-          PACKAGE="${{ steps.extract.outputs.package_name }}"
           TAG="${GITHUB_REF_NAME}"          # e.g. nvidia-setup/0.3.0 or nvidia-setup/0.3.0-rc.1
           VERSION="${TAG#*/}"
           INCLUDE_PATH="${PACKAGE}/**"
@@ -135,10 +135,6 @@ jobs:
             [ -n "${HUMAN}" ] && printf '%s\n\n' "${HUMAN}"
             printf '%s\n' "${BODY}"
           } > "${RUNNER_TEMP:-/tmp}/notes.md"
-          # Use a random delimiter so a literal "EOF" line in release notes can't
-          # truncate the multi-line output variable (GitHub Actions requirement).
-          GH_DELIM="NOTES_EOF_$(openssl rand -hex 8)"
-          { echo "notes<<${GH_DELIM}"; cat "${RUNNER_TEMP:-/tmp}/notes.md"; echo "${GH_DELIM}"; } >> "$GITHUB_OUTPUT"
 
       - name: Create GitHub Release
         env:
@@ -160,9 +156,9 @@ jobs:
             echo "ERROR: tag '${GITHUB_REF_NAME}' does not match <package>/<MAJOR>.<MINOR>.<PATCH> or <package>/<MAJOR>.<MINOR>.<PATCH>-rc.<N>" >&2
             exit 1
           fi
-          if ! gh release view "${{ github.ref_name }}" >/dev/null 2>&1; then
-            gh release create "${{ github.ref_name }}" \
-              --title "${{ github.ref_name }}" \
-              --notes "${{ steps.release_notes.outputs.notes }}" \
+          if ! gh release view "${GITHUB_REF_NAME}" >/dev/null 2>&1; then
+            gh release create "${GITHUB_REF_NAME}" \
+              --title "${GITHUB_REF_NAME}" \
+              --notes-file "${RUNNER_TEMP:-/tmp}/notes.md" \
               ${PRERELEASE_FLAG}
           fi

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -8,6 +8,11 @@ the form `<package>/<version>` with no `v` prefix, for example
 `nvidia-setup/0.3.0`. Pushing such a tag triggers `.github/workflows/release.yml`,
 which builds the release notes and creates the GitHub Release.
 
+Package names (the `<package>` component of a tag) must match `[a-z][a-z0-9-]*`:
+lowercase ASCII letters, digits, and hyphens only, starting with a letter. The
+release workflows enforce this and reject any tag whose package component falls
+outside this grammar.
+
 ## Two-file model
 
 Each package owns two changelog files:

--- a/scripts/release-tag.sh
+++ b/scripts/release-tag.sh
@@ -24,8 +24,10 @@
 # version sort orders pre-releases correctly (see docs/release-process.md).
 #
 # Tags in this repo are <package>/<version> with no "v" prefix (e.g.
-# nvidia-setup/0.3.0). Packages are discovered at runtime as top-level
-# directories containing a config.json.
+# nvidia-setup/0.3.0). The package component must match [a-z][a-z0-9-]*
+# (lowercase letters, digits, hyphens only, starting with a letter); the
+# release workflows enforce this grammar. Packages are discovered at runtime
+# as top-level directories containing a config.json.
 #
 # The tag is created on the current HEAD. Make sure the release commit (CHANGELOG
 # cut, version bump, etc.) is already committed and checked out before tagging.


### PR DESCRIPTION
## Summary

- GitHub Actions `${{ }}` expressions inlined into `run:` blocks are substituted as raw shell text before the runner executes them. Backticks or `$()` in the result execute as subshells, so content from `RELEASE_NOTES.md` or a crafted tag name can run arbitrary commands and exfiltrate secrets.
- Replace all four injection sites: use `${GITHUB_REF_NAME}` (runner env var) instead of `${{ github.ref_name }}`; move `${{ steps.extract.outputs.package_name }}` into an `env:` declaration so it arrives as a literal process variable; replace `--notes "${{ steps.release_notes.outputs.notes }}"` with `--notes-file "${RUNNER_TEMP:-/tmp}/notes.md"` to pass RELEASE_NOTES content out-of-band via the file already written by the prior step.
- Drop the now-unused `id: release_notes` and the `GITHUB_OUTPUT` multi-line notes block.

## Test plan

- [ ] Trigger the release workflow on a test tag and confirm the GitHub Release is created with the correct notes body
- [ ] Confirm a `RELEASE_NOTES.md` section containing backticks does not cause the workflow to execute them
- [ ] Confirm the workflow still works when `RUNNER_TEMP` is set (standard GitHub-hosted runners)