### PR TITLE
fix(tuned): tolerate apt index refresh failures during install

### DIFF
--- a/kdump/README.md
+++ b/kdump/README.md
@@ -38,6 +38,12 @@ path /var/crash
 core_collector makedumpfile -l --message-level 1 -d 31
 ```
 
+## Environment Variables
+
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `APT_ALLOW_INDEX_FAILURE` | No | `true` | Lets `apt update` fail without failing the install step, so one unreachable third-party repo in `/etc/apt/sources.list.d` cannot block the package. Set to `false` to restore strict behavior. The `apt install` that follows is unaffected and still fails if `kdump-tools` is genuinely unavailable. |
+
 ## Lifecycle Stages
 
 ### Apply Stage (`install_kdump.sh`)

--- a/kdump/RELEASE_NOTES.md
+++ b/kdump/RELEASE_NOTES.md
@@ -19,3 +19,17 @@ example is not itself picked up as release notes):
 
     - Notable behavior change worth calling out.
 -->
+
+## 1.0.1
+
+`apt update` failures during install no longer fail the package by default.
+
+Same change as tuned 1.3.2: a single unreachable or stale third-party repo makes
+`apt update` exit 100, which under `set -e` aborted the install step even when
+every index the package actually needs refreshed fine. The `apt install` that
+follows is unchanged and still fails loudly if `kdump-tools` is genuinely
+unavailable.
+
+Set `APT_ALLOW_INDEX_FAILURE=false` in the Skyhook custom resource's package
+`env` to restore the previous strict behavior.
+

--- a/kdump/config.json
+++ b/kdump/config.json
@@ -1,7 +1,7 @@
 {
     "schema_version": "v1",
     "package_name": "kdump",
-    "package_version": "1.0.0",
+    "package_version": "1.0.1",
     "expected_config_files": [],
     "modes": {
         "uninstall": [

--- a/kdump/skyhook_dir/install_kdump.sh
+++ b/kdump/skyhook_dir/install_kdump.sh
@@ -29,7 +29,18 @@ source /etc/os-release
 case $ID in
     ubuntu* | debian*)
         export DEBIAN_FRONTEND=noninteractive
-        apt update -y
+        # Refresh the package indexes. A single unreachable or stale third-party
+        # repo makes `apt update` exit 100, which under `set -e` fails the whole
+        # package even when every index we actually need refreshed fine.
+        # Tolerating that is safe because the `apt install` below is
+        # unconditional and still fails loudly if kdump-tools is genuinely
+        # unavailable. Set APT_ALLOW_INDEX_FAILURE=false on the Skyhook custom
+        # resource's package env to restore strict behavior.
+        if [ "${APT_ALLOW_INDEX_FAILURE:-true}" = "true" ]; then
+            apt update -y || echo "WARN: apt update reported errors; continuing (APT_ALLOW_INDEX_FAILURE=true)" >&2
+        else
+            apt update -y
+        fi
         apt install -o DPKG::Lock::Timeout=60 -y kdump-tools
 
         SERVICE_NAME="kdump-tools"

--- a/nvidia-tuned/README.md
+++ b/nvidia-tuned/README.md
@@ -357,6 +357,7 @@ Both steps are no-ops for every other `service`/`accelerator` pair, so existing 
 |----------|----------|---------|-------------|
 | `TOPO_PATH` | No | `/etc/nccl/topo.xml` | Absolute host path the bundled NCCL topology file is written to. Only used when the configured `service`/`accelerator` pair ships one (today `oci` + `gb300`); otherwise the step is a no-op. Point `NCCL_TOPO_FILE` at the same path in your workloads. |
 | `CONFIGURE_PCIE_ACS` | No | `true` | Set to `false` to skip the PCIe ACS correction and its checks. Only relevant to a `service`/`accelerator` pair that opts in (today `oci` + `gb300`). Use this on nodes whose kernel does not honour `pci=config_acs=`, where the correction cannot take effect and the post-interrupt check would otherwise fail the node. |
+| `APT_ALLOW_INDEX_FAILURE` | No | `true` | Inherited from the `tuned` base package. Lets `apt update` fail without failing the install step, so one unreachable third-party repo in `/etc/apt/sources.list.d` cannot block the package. Set to `false` to restore strict behavior. The `apt install` that follows is unaffected and still fails if the package is genuinely unavailable. |
 
 ## Adding OS-Specific Overrides
 

--- a/nvidia-tuned/RELEASE_NOTES.md
+++ b/nvidia-tuned/RELEASE_NOTES.md
@@ -20,6 +20,14 @@ example is not itself picked up as release notes):
     - Notable behavior change worth calling out.
 -->
 
+## 0.7.2
+
+Picks up tuned 1.3.2, which stops a single unreachable or stale apt repo from
+failing the install step.
+
+Set `APT_ALLOW_INDEX_FAILURE=false` in the Skyhook custom resource's package
+`env` to restore strict behavior.
+
 ## 0.7.1
 
 Fixes the PCIe ACS checks rejecting a node whose GPU driver is not loaded.

--- a/nvidia-tuned/config.json
+++ b/nvidia-tuned/config.json
@@ -1,7 +1,7 @@
 {
     "schema_version": "v1",
     "package_name": "nvidia_tuned",
-    "package_version": "0.7.1",
+    "package_version": "0.7.2",
     "expected_config_files": [
         "accelerator"
     ],

--- a/tuned/README.md
+++ b/tuned/README.md
@@ -131,6 +131,24 @@ env:
     value: true
 ```
 
+#### APT_ALLOW_INDEX_FAILURE
+
+Controls whether a failed `apt update` aborts the install step on Debian/Ubuntu.
+
+- **Purpose**: A single unreachable third-party repo makes `apt update` exit 100. Under `set -e` that failed the whole package, even when every index the package actually needs refreshed fine.
+- **Values**:
+  - `true` or unset: Log a warning and continue (default)
+  - `false`: Fail the install step on any `apt update` error (previous behavior)
+- **When to use**: Set to `false` on nodes where a stale package index must be treated as fatal.
+- **Behavior**: Only the index refresh is relaxed. The `apt install` that follows is unconditional and still fails loudly if `tuned` is genuinely unavailable.
+
+**Example configuration in SCR:**
+```yaml
+env:
+    name: APT_ALLOW_INDEX_FAILURE
+    value: "false"
+```
+
 ### Configmaps
 
 The package expects configmaps to be available in `${SKYHOOK_DIR}/configmaps/`:

--- a/tuned/RELEASE_NOTES.md
+++ b/tuned/RELEASE_NOTES.md
@@ -20,6 +20,20 @@ example is not itself picked up as release notes):
     - Notable behavior change worth calling out.
 -->
 
+## 1.3.2
+
+`apt update` failures during install no longer fail the package by default.
+
+A single unreachable or stale third-party repo makes `apt update` exit 100, and
+under `set -e` that aborted the whole install step even when every index the
+package actually needs refreshed fine. The `apt install` that follows is
+unchanged and still fails loudly if `tuned` is genuinely unavailable, so a real
+repo outage is still caught.
+
+Set `APT_ALLOW_INDEX_FAILURE=false` in the Skyhook custom resource's package
+`env` to restore the previous strict behavior. No action is required to pick up
+the new default.
+
 ## 1.3.1
 
 - Fixed profile validation so profiles that carry a `summary` in `tuned-adm

--- a/tuned/config.json
+++ b/tuned/config.json
@@ -1,7 +1,7 @@
 {
     "schema_version": "v1",
     "package_name": "tuned",
-    "package_version": "1.3.1",
+    "package_version": "1.3.2",
     "expected_config_files": [],
     "modes": {
         "uninstall": [

--- a/tuned/skyhook_dir/install_tuned.sh
+++ b/tuned/skyhook_dir/install_tuned.sh
@@ -25,7 +25,18 @@ case $ID in
     ubuntu* | debian*)
         export DEBIAN_FRONTEND=noninteractive
 
-        apt update -y
+        # Refresh the package indexes. A single unreachable or stale third-party
+        # repo makes `apt update` exit 100, which under `set -e` fails the whole
+        # package even when every index we actually need refreshed fine.
+        # Tolerating that is safe because the `apt install` below is
+        # unconditional and still fails loudly if tuned is genuinely
+        # unavailable. Set APT_ALLOW_INDEX_FAILURE=false on the Skyhook custom
+        # resource's package env to restore strict behavior.
+        if [ "${APT_ALLOW_INDEX_FAILURE:-true}" = "true" ]; then
+            apt update -y || echo "WARN: apt update reported errors; continuing (APT_ALLOW_INDEX_FAILURE=true)" >&2
+        else
+            apt update -y
+        fi
         apt install -o DPKG::Lock::Timeout=60 -y tuned
     ;;
     centos* | redhat* | amzn*)


### PR DESCRIPTION
## Summary

`apt update` failures no longer abort the install step of `tuned` and `kdump`. The behavior is configurable, and strict mode is one env var away.

## Problem

Both packages run their install script under `set -e` and call `apt update` before `apt install`:

```bash
set -xe
...
apt update -y
apt install -o DPKG::Lock::Timeout=60 -y tuned
```

`apt update` exits **100** if *any* configured source fails to refresh — including a third-party repo the package has nothing to do with. Under `set -e` that aborts the whole step, so the package fails on every node even when every index it actually needs refreshed fine.

This makes an unrelated repo going stale or unreachable a hard node-level failure, and the resulting apply step crash-loops rather than degrading.

## Change

Relax **only** the index refresh:

```bash
if [ "${APT_ALLOW_INDEX_FAILURE:-true}" = "true" ]; then
    apt update -y || echo "WARN: apt update reported errors; continuing (APT_ALLOW_INDEX_FAILURE=true)" >&2
else
    apt update -y
fi
apt install -o DPKG::Lock::Timeout=60 -y tuned
```

The `apt install` that follows is unconditional and unchanged. If the package is genuinely unavailable — a real repo outage, a bad mirror — it still fails loudly. Only "an index I don't need didn't refresh" is tolerated.

## Configuration

New env var, set via the Skyhook custom resource's package `env` (same mechanism as the existing `TOPO_PATH` and `CONFIGURE_PCIE_ACS`):

| Variable | Required | Default | Description |
|---|---|---|---|
| `APT_ALLOW_INDEX_FAILURE` | No | `true` | Allow `apt update` to fail without failing the install step. Set to `false` for the previous strict behavior. |

```yaml
env:
  - name: APT_ALLOW_INDEX_FAILURE
    value: "false"   # restore strict behavior
```

**Default is `true` (relaxed)** so consumers pick up the fix on version bump alone, with no CR edits. Happy to flip it to strict-by-default if reviewers prefer opt-in — it's a one-word change, but then every consumer needs a CR edit before it helps them.

## Versions

| Package | Version | Notes |
|---|---|---|
| `tuned` | 1.3.1 → **1.3.2** | The fix |
| `kdump` | 1.0.0 → **1.0.1** | Identical latent bug, same fix |
| `nvidia-tuned` | 0.7.1 → **0.7.2** | Rebases onto `tuned` 1.3.2 |

`kdump` was not observed failing — it carries the same `set -e` + `apt update` pattern and is fixed preemptively.

The `nvidia-tuned` Dockerfile `ARG TUNED_VERSION` bump is a local-dev default only; CI resolves the tuned tag via `preprocess.sh`.

## Testing

- `bash -n` clean on both modified scripts.
- Both branches exercised with a stubbed `apt update` returning 100: default → reaches `apt install`, exits 0; `APT_ALLOW_INDEX_FAILURE=false` → exits 100.
- All three `config.json` files parse and keep their schema shape.
- All three commit subjects pass commitlint.

## Notes for reviewers

- `CHANGELOG.md` is deliberately untouched — it is git-cliff generated. Hand-authored notes went to each package's `RELEASE_NOTES.md`.
- Three commits, one scope each, so each package's generated changelog picks up its own entry.
- All commits are DCO signed off.
- `shellcheck` was not available locally; CI's `lint-shellcheck` is the first real run.
