### PR TITLE
feat(nvidia-tuned): Disable IOMMU passthrough on kernels needing it for ACS + DMA-BUF

### DIFF
--- a/nvidia-tuned/README.md
+++ b/nvidia-tuned/README.md
@@ -286,6 +286,14 @@ host-level steps do need a reboot:
   `pci=config_acs=`; on a node whose kernel does not, set `CONFIGURE_PCIE_ACS=false`
   (see the environment variables below), keep `nvidia_peermem` loaded, and keep
   `NCCL_DMABUF_ENABLE=0` set.
+- **IOMMU passthrough on old kernels.** Needed to run ACS + DMA-BUF on kernels older
+  than 6.11. OCI ships `iommu.passthrough=1`, and arm-smmu-v3 before 6.11 cannot attach
+  a PASID to an identity domain, so `nvidia_uvm`'s ATS/SVA bind fails with `-E2BIG` and
+  **no CUDA context can be created at all** — `cudaMalloc` reports the GPUs as busy on an
+  idle node. The `configure-iommu-passthrough` step writes a
+  `/etc/default/grub.d/99-iommu-passthrough.cfg` drop-in setting `iommu.passthrough=0`,
+  restoring translating domains and with them CUDA, GPUDirect RDMA and DMA-BUF. Defaults
+  to `auto` (apply below 6.11). Independent of the ACS correction; both can be active.
 - **RDMA VF boot gate.** The `install-rdma-vfs-ready` step installs a
   `rdma-vfs-ready.service` unit that orders before `kubelet.service` and waits for the
   Oracle Cloud Agent to create the RDMA VFs. It is a boot-ordering gate, so it only has
@@ -357,6 +365,7 @@ Both steps are no-ops for every other `service`/`accelerator` pair, so existing 
 |----------|----------|---------|-------------|
 | `TOPO_PATH` | No | `/etc/nccl/topo.xml` | Absolute host path the bundled NCCL topology file is written to. Only used when the configured `service`/`accelerator` pair ships one (today `oci` + `gb300`); otherwise the step is a no-op. Point `NCCL_TOPO_FILE` at the same path in your workloads. |
 | `CONFIGURE_PCIE_ACS` | No | `true` | Set to `false` to skip the PCIe ACS correction and its checks. Only relevant to a `service`/`accelerator` pair that opts in (today `oci` + `gb300`). Use this on nodes whose kernel does not honour `pci=config_acs=`, where the correction cannot take effect and the post-interrupt check would otherwise fail the node. |
+| `CONFIGURE_IOMMU_PASSTHROUGH` | No | `auto` | Controls the IOMMU passthrough workaround for kernels whose arm-smmu-v3 cannot attach a PASID to an identity domain. `auto` applies it only when the running kernel is older than 6.11; `true` always applies it; `false` never does and skips the checks. Only relevant to a `service`/`accelerator` pair that opts in (today `oci` + `gb300`). Set `false` on a node whose kernel carries a backported fix that the version check cannot see. |
 | `APT_ALLOW_INDEX_FAILURE` | No | `true` | Inherited from the `tuned` base package. Lets `apt update` fail without failing the install step, so one unreachable third-party repo in `/etc/apt/sources.list.d` cannot block the package. Set to `false` to restore strict behavior. The `apt install` that follows is unaffected and still fails if the package is genuinely unavailable. |
 
 ## Adding OS-Specific Overrides

--- a/nvidia-tuned/README.md
+++ b/nvidia-tuned/README.md
@@ -250,7 +250,7 @@ spec:
   packages:
     nvidia-tuned:
       image: ghcr.io/nvidia/nodewright-packages/nvidia-tuned
-      version: 0.7.0
+      version: 0.8.0
       interrupt:
         type: reboot
       env:
@@ -289,11 +289,14 @@ host-level steps do need a reboot:
 - **IOMMU passthrough on old kernels.** Needed to run ACS + DMA-BUF on kernels older
   than 6.11. OCI ships `iommu.passthrough=1`, and arm-smmu-v3 before 6.11 cannot attach
   a PASID to an identity domain, so `nvidia_uvm`'s ATS/SVA bind fails with `-E2BIG` and
-  **no CUDA context can be created at all** — `cudaMalloc` reports the GPUs as busy on an
+  **no CUDA context can be created at all**: `cudaMalloc` reports the GPUs as busy on an
   idle node. The `configure-iommu-passthrough` step writes a
   `/etc/default/grub.d/99-iommu-passthrough.cfg` drop-in setting `iommu.passthrough=0`,
   restoring translating domains and with them CUDA, GPUDirect RDMA and DMA-BUF. Defaults
-  to `auto` (apply below 6.11). Independent of the ACS correction; both can be active.
+  to `auto` (apply below 6.11). When the policy stops applying, because the node was
+  switched off or its kernel was upgraded past the threshold, the drop-in is removed and
+  GRUB regenerated, so passthrough comes back on the next boot. Independent of the ACS
+  correction; both can be active.
 - **RDMA VF boot gate.** The `install-rdma-vfs-ready` step installs a
   `rdma-vfs-ready.service` unit that orders before `kubelet.service` and waits for the
   Oracle Cloud Agent to create the RDMA VFs. It is a boot-ordering gate, so it only has

--- a/nvidia-tuned/README.md
+++ b/nvidia-tuned/README.md
@@ -295,8 +295,10 @@ host-level steps do need a reboot:
   restoring translating domains and with them CUDA, GPUDirect RDMA and DMA-BUF. Defaults
   to `auto` (apply below 6.11). When the policy stops applying, because the node was
   switched off or its kernel was upgraded past the threshold, the drop-in is removed and
-  GRUB regenerated, so passthrough comes back on the next boot. Independent of the ACS
-  correction; both can be active.
+  GRUB regenerated, so passthrough comes back on the next boot. It is scoped to affected
+  kernels rather than applied everywhere because translating domains cost DMA performance,
+  which is why passthrough is set in the first place; on a kernel with the fix there is no
+  benefit to pay for. Independent of the ACS correction; both can be active.
 - **RDMA VF boot gate.** The `install-rdma-vfs-ready` step installs a
   `rdma-vfs-ready.service` unit that orders before `kubelet.service` and waits for the
   Oracle Cloud Agent to create the RDMA VFs. It is a boot-ordering gate, so it only has

--- a/nvidia-tuned/RELEASE_NOTES.md
+++ b/nvidia-tuned/RELEASE_NOTES.md
@@ -20,6 +20,26 @@ example is not itself picked up as release notes):
     - Notable behavior change worth calling out.
 -->
 
+## 0.8.0
+
+Adds an IOMMU passthrough workaround needed to run ACS + DMA-BUF on kernels older than
+6.11, gated on `oci` + `gb300` like the PCIe ACS correction.
+
+OCI ships `iommu.passthrough=1`, and arm-smmu-v3 before 6.11 cannot attach a PASID to an
+identity domain, so `nvidia_uvm`'s ATS/SVA bind fails with `-E2BIG` and no CUDA context
+can be created — `cudaMalloc` reports the GPUs as busy on an idle node, taking DCGM, the
+GPU operator validators and every workload with it. The new `configure-iommu-passthrough`
+step writes a `99-iommu-passthrough.cfg` grub drop-in setting `iommu.passthrough=0`.
+
+Defaults to `CONFIGURE_IOMMU_PASSTHROUGH=auto`, applying only on kernels older than
+6.11. Vendor kernels backport, so `auto` can guess wrong either way; set `false` to keep
+passthrough or `true` to force the change.
+
+Upgrade note: changes the kernel command line, so it takes effect on the next boot via
+the `interrupt: {type: reboot}` this package already requires. Nodes at or above the
+threshold are unaffected. Translating domains cost some DMA performance; the trade is
+against those nodes being unable to run CUDA at all.
+
 ## 0.7.2
 
 Picks up tuned 1.3.2, which stops a single unreachable or stale apt repo from

--- a/nvidia-tuned/RELEASE_NOTES.md
+++ b/nvidia-tuned/RELEASE_NOTES.md
@@ -27,13 +27,17 @@ Adds an IOMMU passthrough workaround needed to run ACS + DMA-BUF on kernels olde
 
 OCI ships `iommu.passthrough=1`, and arm-smmu-v3 before 6.11 cannot attach a PASID to an
 identity domain, so `nvidia_uvm`'s ATS/SVA bind fails with `-E2BIG` and no CUDA context
-can be created — `cudaMalloc` reports the GPUs as busy on an idle node, taking DCGM, the
+can be created: `cudaMalloc` reports the GPUs as busy on an idle node, taking DCGM, the
 GPU operator validators and every workload with it. The new `configure-iommu-passthrough`
 step writes a `99-iommu-passthrough.cfg` grub drop-in setting `iommu.passthrough=0`.
 
 Defaults to `CONFIGURE_IOMMU_PASSTHROUGH=auto`, applying only on kernels older than
 6.11. Vendor kernels backport, so `auto` can guess wrong either way; set `false` to keep
 passthrough or `true` to force the change.
+
+Setting `false`, or upgrading a node past the threshold under `auto`, removes a drop-in
+this package previously wrote and regenerates GRUB, so passthrough returns on the next
+boot rather than staying pinned off.
 
 Upgrade note: changes the kernel command line, so it takes effect on the next boot via
 the `interrupt: {type: reboot}` this package already requires. Nodes at or above the

--- a/nvidia-tuned/config.json
+++ b/nvidia-tuned/config.json
@@ -1,7 +1,7 @@
 {
     "schema_version": "v1",
     "package_name": "nvidia_tuned",
-    "package_version": "0.7.2",
+    "package_version": "0.8.0",
     "expected_config_files": [
         "accelerator"
     ],
@@ -188,6 +188,18 @@
                 "upgrade_step": false
             },
             {
+                "name": "configure-iommu-passthrough",
+                "path": "configure_iommu_passthrough.sh",
+                "arguments": [],
+                "returncodes": [
+                    0
+                ],
+                "on_host": true,
+                "env": {},
+                "idempotence": false,
+                "upgrade_step": false
+            },
+            {
                 "name": "configure-spcx-cc",
                 "path": "configure_spcx_cc.sh",
                 "arguments": [],
@@ -262,6 +274,18 @@
                 "upgrade_step": false
             },
             {
+                "name": "configure-iommu-passthrough-check",
+                "path": "configure_iommu_passthrough_check.sh",
+                "arguments": [],
+                "returncodes": [
+                    0
+                ],
+                "on_host": true,
+                "env": {},
+                "idempotence": true,
+                "upgrade_step": false
+            },
+            {
                 "name": "configure-spcx-cc-check",
                 "path": "configure_spcx_cc_check.sh",
                 "arguments": [],
@@ -302,6 +326,18 @@
             {
                 "name": "post-interrupt-pcie-acs-check",
                 "path": "post_interrupt_pcie_acs_check.sh",
+                "arguments": [],
+                "returncodes": [
+                    0
+                ],
+                "on_host": true,
+                "env": {},
+                "idempotence": true,
+                "upgrade_step": false
+            },
+            {
+                "name": "post-interrupt-iommu-passthrough-check",
+                "path": "post_interrupt_iommu_passthrough_check.sh",
                 "arguments": [],
                 "returncodes": [
                     0

--- a/nvidia-tuned/profiles/service/oci/iommu-passthrough-gb300.enabled
+++ b/nvidia-tuned/profiles/service/oci/iommu-passthrough-gb300.enabled
@@ -1,0 +1,7 @@
+# Marker: opt this service/accelerator pair in to the IOMMU passthrough workaround run
+# by skyhook_dir/configure_iommu_passthrough.sh. The file is a switch; its contents are
+# ignored.
+#
+# Needed to run ACS + DMA-BUF on kernels older than 6.11, whose arm-smmu-v3 cannot
+# attach a PASID to an identity domain. Requires a reboot, so a custom resource
+# selecting this pair must declare `interrupt: {type: reboot}`.

--- a/nvidia-tuned/skyhook_dir/configure_iommu_passthrough.sh
+++ b/nvidia-tuned/skyhook_dir/configure_iommu_passthrough.sh
@@ -27,6 +27,11 @@
 # Upstream: 6.10 made CD tables allocate-on-demand, 6.11 added S1DSS_BYPASS (PASID on an
 # identity STE). 6.11 is the threshold.
 #
+# Scoped to affected kernels rather than applied everywhere because translating domains
+# cost DMA performance, which is why the platform sets passthrough in the first place. On
+# a kernel with the fix there is nothing to buy with that cost, so applying it there would
+# be a straight regression on nodes that are already healthy.
+#
 # Gated on ${SKYHOOK_DIR}/profiles/service/${service}/iommu-passthrough-${accelerator}.enabled,
 # so pairs without the marker are a no-op. CONFIGURE_IOMMU_PASSTHROUGH picks the policy:
 # auto (default, apply below IOMMU_PASSTHROUGH_MIN_KERNEL), true (always), false (never).

--- a/nvidia-tuned/skyhook_dir/configure_iommu_passthrough.sh
+++ b/nvidia-tuned/skyhook_dir/configure_iommu_passthrough.sh
@@ -50,13 +50,14 @@ IOMMU_PASSTHROUGH_MIN_KERNEL="${IOMMU_PASSTHROUGH_MIN_KERNEL:-6.11}"
 # iommu.passthrough is an early_param and do_early_param() runs the handler on each
 # occurrence in order, so the last value wins. Appending rather than rewriting keeps this
 # correct whether or not the platform ships its own drop-in.
-read -r -d '' DROPIN_CONTENT <<'EOF' || true
+DROPIN_CONTENT="$(cat <<'EOF'
 # Managed by the nvidia-tuned Skyhook package. Do not edit.
 #
 # arm-smmu-v3 before 6.11 cannot attach a PASID to an identity domain, which breaks GPU
 # ATS/SVA under iommu.passthrough=1. Sorts last so this value is the one that applies.
 GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX iommu.passthrough=0"
 EOF
+)"
 
 # Returns 0 when the configured service/accelerator opts in.
 iommu_enabled() {
@@ -129,6 +130,17 @@ regenerate_grub() {
     fi
 }
 
+# Drop a drop-in this package previously wrote. Without this, `false` cannot restore
+# passthrough and a kernel upgraded past the threshold keeps the workaround pinned on,
+# because the stale file still contributes iommu.passthrough=0 at the next boot.
+remove_dropin() {
+    [[ -f "${IOMMU_GRUB_DROPIN}" ]] || return 0
+
+    rm -f "${IOMMU_GRUB_DROPIN}"
+    regenerate_grub
+    echo "Removed ${IOMMU_GRUB_DROPIN}; a reboot is required to restore IOMMU passthrough"
+}
+
 main() {
     local policy
     policy="$(iommu_policy)"
@@ -139,12 +151,14 @@ main() {
     fi
 
     if [[ "${policy}" == "never" ]]; then
-        echo "IOMMU passthrough workaround switched off via CONFIGURE_IOMMU_PASSTHROUGH; nothing to do"
+        echo "IOMMU passthrough workaround switched off via CONFIGURE_IOMMU_PASSTHROUGH"
+        remove_dropin
         return 0
     fi
 
     if [[ "${policy}" == "auto" ]] && ! kernel_predates_fix; then
-        echo "Kernel $(uname -r) is >= ${IOMMU_PASSTHROUGH_MIN_KERNEL}; nothing to do"
+        echo "Kernel $(uname -r) is >= ${IOMMU_PASSTHROUGH_MIN_KERNEL}; passthrough is fine here"
+        remove_dropin
         return 0
     fi
 

--- a/nvidia-tuned/skyhook_dir/configure_iommu_passthrough.sh
+++ b/nvidia-tuned/skyhook_dir/configure_iommu_passthrough.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Disables IOMMU passthrough on kernels that need it to run ACS + DMA-BUF.
+#
+# OCI ships iommu.passthrough=1, so devices sit behind an identity domain. arm-smmu-v3
+# before 6.11 cannot attach a PASID to an identity domain, so nvidia_uvm's ATS/SVA bind
+# fails with -E2BIG and no CUDA context can be created at all -- cudaMalloc reports the
+# GPUs as busy on an idle node. Setting iommu.passthrough=0 restores translating domains,
+# and with them CUDA, GPUDirect RDMA and the DMA-BUF path the ACS correction sets up.
+#
+# Upstream: 6.10 made CD tables allocate-on-demand, 6.11 added S1DSS_BYPASS (PASID on an
+# identity STE). 6.11 is the threshold.
+#
+# Gated on ${SKYHOOK_DIR}/profiles/service/${service}/iommu-passthrough-${accelerator}.enabled,
+# so pairs without the marker are a no-op. CONFIGURE_IOMMU_PASSTHROUGH picks the policy:
+# auto (default, apply below IOMMU_PASSTHROUGH_MIN_KERNEL), true (always), false (never).
+# auto reads uname and vendor kernels backport, so it can guess wrong either way; the
+# explicit values are the escape hatch.
+#
+# Lands on the kernel command line, so it needs `interrupt: {type: reboot}`.
+
+set -euo pipefail
+
+CONFIGMAP_DIR="${SKYHOOK_DIR}/configmaps"
+PROFILES_DIR="${SKYHOOK_DIR}/profiles"
+
+# Overridable so tests can point at a stub.
+IOMMU_GRUB_DROPIN="${IOMMU_GRUB_DROPIN:-/etc/default/grub.d/99-iommu-passthrough.cfg}"
+# First kernel with arm-smmu-v3 S1DSS_BYPASS. Overridable so tests can pin the
+# threshold; not an operator knob -- use CONFIGURE_IOMMU_PASSTHROUGH instead.
+IOMMU_PASSTHROUGH_MIN_KERNEL="${IOMMU_PASSTHROUGH_MIN_KERNEL:-6.11}"
+
+# 99- sorts after every numbered producer, so this assignment is evaluated last.
+# iommu.passthrough is an early_param and do_early_param() runs the handler on each
+# occurrence in order, so the last value wins. Appending rather than rewriting keeps this
+# correct whether or not the platform ships its own drop-in.
+read -r -d '' DROPIN_CONTENT <<'EOF' || true
+# Managed by the nvidia-tuned Skyhook package. Do not edit.
+#
+# arm-smmu-v3 before 6.11 cannot attach a PASID to an identity domain, which breaks GPU
+# ATS/SVA under iommu.passthrough=1. Sorts last so this value is the one that applies.
+GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX iommu.passthrough=0"
+EOF
+
+# Returns 0 when the configured service/accelerator opts in.
+iommu_enabled() {
+    local service accelerator
+
+    [[ -f "${CONFIGMAP_DIR}/service" ]] || return 1
+    service="$(xargs < "${CONFIGMAP_DIR}/service")"
+    [[ -n "${service}" ]] || return 1
+
+    [[ -f "${CONFIGMAP_DIR}/accelerator" ]] || return 1
+    accelerator="$(xargs < "${CONFIGMAP_DIR}/accelerator")"
+    [[ -n "${accelerator}" ]] || return 1
+
+    [[ -f "${PROFILES_DIR}/service/${service}/iommu-passthrough-${accelerator}.enabled" ]]
+}
+
+# Echoes always | never | auto. Unrecognised values are auto.
+iommu_policy() {
+    local setting
+    setting="$(printf '%s' "${CONFIGURE_IOMMU_PASSTHROUGH:-auto}" | tr '[:upper:]' '[:lower:]')"
+    case "${setting}" in
+        false | 0 | no | off) echo "never" ;;
+        true | 1 | yes | on) echo "always" ;;
+        *) echo "auto" ;;
+    esac
+}
+
+# Returns 0 when uname -r is older than IOMMU_PASSTHROUGH_MIN_KERNEL (major.minor only).
+# An unparseable version is treated as new enough: applying a boot-affecting change to an
+# unknown platform is the worse failure.
+kernel_predates_fix() {
+    local rel major minor want_major want_minor
+
+    rel="$(uname -r)"
+    major="${rel%%.*}"
+    minor="${rel#*.}"
+    minor="${minor%%.*}"
+
+    want_major="${IOMMU_PASSTHROUGH_MIN_KERNEL%%.*}"
+    want_minor="${IOMMU_PASSTHROUGH_MIN_KERNEL#*.}"
+    want_minor="${want_minor%%.*}"
+
+    if ! [[ "${major}" =~ ^[0-9]+$ && "${minor}" =~ ^[0-9]+$ ]]; then
+        echo "WARNING: cannot parse kernel version '${rel}'; treating as new enough"
+        return 1
+    fi
+
+    if (( major < want_major )); then
+        return 0
+    fi
+    if (( major == want_major && minor < want_minor )); then
+        return 0
+    fi
+    return 1
+}
+
+# Mirrors the fallback chain in kdump's update_grub_config().
+regenerate_grub() {
+    if command -v update-grub >/dev/null 2>&1; then
+        update-grub
+    elif command -v grub2-mkconfig >/dev/null 2>&1; then
+        if [[ -d /boot/grub2 ]]; then
+            grub2-mkconfig -o /boot/grub2/grub.cfg
+        else
+            grub2-mkconfig -o /boot/efi/EFI/redhat/grub.cfg
+        fi
+    else
+        echo "ERROR: neither update-grub nor grub2-mkconfig is available"
+        exit 1
+    fi
+}
+
+main() {
+    local policy
+    policy="$(iommu_policy)"
+
+    if ! iommu_enabled; then
+        echo "IOMMU passthrough workaround not enabled for this service/accelerator; nothing to do"
+        return 0
+    fi
+
+    if [[ "${policy}" == "never" ]]; then
+        echo "IOMMU passthrough workaround switched off via CONFIGURE_IOMMU_PASSTHROUGH; nothing to do"
+        return 0
+    fi
+
+    if [[ "${policy}" == "auto" ]] && ! kernel_predates_fix; then
+        echo "Kernel $(uname -r) is >= ${IOMMU_PASSTHROUGH_MIN_KERNEL}; nothing to do"
+        return 0
+    fi
+
+    # Compare content rather than just existence, so a drop-in left by an older version of
+    # this package is corrected instead of silently kept.
+    if [[ -f "${IOMMU_GRUB_DROPIN}" ]] \
+        && [[ "$(cat "${IOMMU_GRUB_DROPIN}")" == "${DROPIN_CONTENT}" ]]; then
+        echo "IOMMU passthrough drop-in already current at ${IOMMU_GRUB_DROPIN}; nothing to do"
+        return 0
+    fi
+
+    echo "Kernel $(uname -r) predates ${IOMMU_PASSTHROUGH_MIN_KERNEL}; disabling IOMMU passthrough"
+    mkdir -p "$(dirname "${IOMMU_GRUB_DROPIN}")"
+    printf '%s\n' "${DROPIN_CONTENT}" > "${IOMMU_GRUB_DROPIN}"
+    regenerate_grub
+    echo "Wrote ${IOMMU_GRUB_DROPIN}; a reboot is required for it to take effect"
+}
+
+main "$@"

--- a/nvidia-tuned/skyhook_dir/configure_iommu_passthrough_check.sh
+++ b/nvidia-tuned/skyhook_dir/configure_iommu_passthrough_check.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Verifies configure_iommu_passthrough.sh left a drop-in that will disable IOMMU
+# passthrough on the next boot.
+#
+# Runs before the reboot, so live state still shows passthrough; passing only means the
+# drop-in is in place. post_interrupt_iommu_passthrough_check.sh asserts it took effect.
+# A non-zero exit is the signal, so no `set -e`.
+
+set -uo pipefail
+
+CONFIGMAP_DIR="${SKYHOOK_DIR}/configmaps"
+PROFILES_DIR="${SKYHOOK_DIR}/profiles"
+
+IOMMU_GRUB_DROPIN="${IOMMU_GRUB_DROPIN:-/etc/default/grub.d/99-iommu-passthrough.cfg}"
+# First kernel with arm-smmu-v3 S1DSS_BYPASS. Overridable so tests can pin the
+# threshold; not an operator knob -- use CONFIGURE_IOMMU_PASSTHROUGH instead.
+IOMMU_PASSTHROUGH_MIN_KERNEL="${IOMMU_PASSTHROUGH_MIN_KERNEL:-6.11}"
+
+# Mirrors iommu_enabled() in configure_iommu_passthrough.sh.
+iommu_enabled() {
+    local service accelerator
+
+    [[ -f "${CONFIGMAP_DIR}/service" ]] || return 1
+    service="$(xargs < "${CONFIGMAP_DIR}/service")"
+    [[ -n "${service}" ]] || return 1
+
+    [[ -f "${CONFIGMAP_DIR}/accelerator" ]] || return 1
+    accelerator="$(xargs < "${CONFIGMAP_DIR}/accelerator")"
+    [[ -n "${accelerator}" ]] || return 1
+
+    [[ -f "${PROFILES_DIR}/service/${service}/iommu-passthrough-${accelerator}.enabled" ]]
+}
+
+# Mirrors iommu_policy() in configure_iommu_passthrough.sh.
+iommu_policy() {
+    local setting
+    setting="$(printf '%s' "${CONFIGURE_IOMMU_PASSTHROUGH:-auto}" | tr '[:upper:]' '[:lower:]')"
+    case "${setting}" in
+        false | 0 | no | off) echo "never" ;;
+        true | 1 | yes | on) echo "always" ;;
+        *) echo "auto" ;;
+    esac
+}
+
+# Mirrors kernel_predates_fix() in configure_iommu_passthrough.sh.
+kernel_predates_fix() {
+    local rel major minor want_major want_minor
+
+    rel="$(uname -r)"
+    major="${rel%%.*}"
+    minor="${rel#*.}"
+    minor="${minor%%.*}"
+
+    want_major="${IOMMU_PASSTHROUGH_MIN_KERNEL%%.*}"
+    want_minor="${IOMMU_PASSTHROUGH_MIN_KERNEL#*.}"
+    want_minor="${want_minor%%.*}"
+
+    if ! [[ "${major}" =~ ^[0-9]+$ && "${minor}" =~ ^[0-9]+$ ]]; then
+        return 1
+    fi
+
+    if (( major < want_major )); then
+        return 0
+    fi
+    if (( major == want_major && minor < want_minor )); then
+        return 0
+    fi
+    return 1
+}
+
+main() {
+    local policy
+    policy="$(iommu_policy)"
+
+    if ! iommu_enabled; then
+        echo "IOMMU passthrough workaround not enabled for this service/accelerator; nothing to verify"
+        return 0
+    fi
+
+    if [[ "${policy}" == "never" ]]; then
+        echo "IOMMU passthrough workaround switched off via CONFIGURE_IOMMU_PASSTHROUGH; nothing to verify"
+        return 0
+    fi
+
+    if [[ "${policy}" == "auto" ]] && ! kernel_predates_fix; then
+        echo "Kernel $(uname -r) is >= ${IOMMU_PASSTHROUGH_MIN_KERNEL}; no drop-in expected"
+        return 0
+    fi
+
+    if [[ ! -f "${IOMMU_GRUB_DROPIN}" ]]; then
+        echo "ERROR: IOMMU passthrough workaround was requested but no bootloader drop-in exists at ${IOMMU_GRUB_DROPIN}"
+        exit 1
+    fi
+
+    # Match an active assignment, not a commented one, so a drop-in that contributes
+    # nothing fails here rather than after the reboot. Comment-strip first; see the
+    # equivalent note in configure_pcie_acs_check.sh for why one regex is not enough.
+    if ! awk '{ sub(/#.*/, ""); if ($0 ~ /iommu\.passthrough=0/) found = 1 } END { exit !found }' \
+        "${IOMMU_GRUB_DROPIN}"; then
+        echo "ERROR: ${IOMMU_GRUB_DROPIN} does not contain an active iommu.passthrough=0 setting"
+        exit 1
+    fi
+
+    echo "Verified IOMMU passthrough drop-in at ${IOMMU_GRUB_DROPIN}; pending reboot"
+}
+
+main "$@"

--- a/nvidia-tuned/skyhook_dir/post_interrupt_iommu_passthrough_check.sh
+++ b/nvidia-tuned/skyhook_dir/post_interrupt_iommu_passthrough_check.sh
@@ -135,6 +135,14 @@ main() {
 
     effective="$(effective_passthrough)"
 
+    # Unset is a failure, not a pass. The drop-in sets the token explicitly, so its absence
+    # means nothing this package wrote reached the booted kernel. Accepting it because the
+    # kernel happened to default to translated would hide a drop-in that never applied.
+    if [[ -z "${effective}" ]]; then
+        fail_not_applied \
+            "The booted kernel command line (${PROC_CMDLINE}) carries no iommu.passthrough argument, so the drop-in never reached the kernel. Check for a later-sorting file in /etc/default/grub.d/ that overwrites GRUB_CMDLINE_LINUX, and check which entry GRUB_DEFAULT boots."
+    fi
+
     if [[ "${effective}" == "1" ]]; then
         fail_not_applied \
             "The booted kernel command line still resolves iommu.passthrough to 1. The last occurrence wins, so a file sorting after 99-iommu-passthrough.cfg in /etc/default/grub.d/ is overriding it, or the drop-in never reached grub.cfg. Check which entry GRUB_DEFAULT boots."
@@ -145,7 +153,7 @@ main() {
             "No IOMMU group under ${IOMMU_GROUPS_DIR} is using a translating (DMA or DMA-FQ) domain, so the SMMU is still in bypass. 'dmesg | grep \"Default domain type\"' shows what the kernel resolved at boot."
     fi
 
-    echo "Verified IOMMU translation is active after reboot (iommu.passthrough=${effective:-unset})"
+    echo "Verified IOMMU translation is active after reboot (iommu.passthrough=${effective})"
 }
 
 # The only place an operator will look, so name the cause, the cost and the switch.

--- a/nvidia-tuned/skyhook_dir/post_interrupt_iommu_passthrough_check.sh
+++ b/nvidia-tuned/skyhook_dir/post_interrupt_iommu_passthrough_check.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Verifies IOMMU translation is live after the reboot interrupt.
+#
+# GATES: if the workaround was requested and did not take effect, the node cannot run
+# CUDA at all, so this fails rather than letting it come up broken.
+# CONFIGURE_IOMMU_PASSTHROUGH=false skips both the change and this check.
+
+set -uo pipefail
+
+CONFIGMAP_DIR="${SKYHOOK_DIR}/configmaps"
+PROFILES_DIR="${SKYHOOK_DIR}/profiles"
+
+PROC_CMDLINE="${PROC_CMDLINE:-/proc/cmdline}"
+IOMMU_GROUPS_DIR="${IOMMU_GROUPS_DIR:-/sys/kernel/iommu_groups}"
+# First kernel with arm-smmu-v3 S1DSS_BYPASS. Overridable so tests can pin the
+# threshold; not an operator knob -- use CONFIGURE_IOMMU_PASSTHROUGH instead.
+IOMMU_PASSTHROUGH_MIN_KERNEL="${IOMMU_PASSTHROUGH_MIN_KERNEL:-6.11}"
+
+# Mirrors iommu_enabled() in configure_iommu_passthrough.sh.
+iommu_enabled() {
+    local service accelerator
+
+    [[ -f "${CONFIGMAP_DIR}/service" ]] || return 1
+    service="$(xargs < "${CONFIGMAP_DIR}/service")"
+    [[ -n "${service}" ]] || return 1
+
+    [[ -f "${CONFIGMAP_DIR}/accelerator" ]] || return 1
+    accelerator="$(xargs < "${CONFIGMAP_DIR}/accelerator")"
+    [[ -n "${accelerator}" ]] || return 1
+
+    [[ -f "${PROFILES_DIR}/service/${service}/iommu-passthrough-${accelerator}.enabled" ]]
+}
+
+# Mirrors iommu_policy() in configure_iommu_passthrough.sh.
+iommu_policy() {
+    local setting
+    setting="$(printf '%s' "${CONFIGURE_IOMMU_PASSTHROUGH:-auto}" | tr '[:upper:]' '[:lower:]')"
+    case "${setting}" in
+        false | 0 | no | off) echo "never" ;;
+        true | 1 | yes | on) echo "always" ;;
+        *) echo "auto" ;;
+    esac
+}
+
+# Mirrors kernel_predates_fix() in configure_iommu_passthrough.sh.
+kernel_predates_fix() {
+    local rel major minor want_major want_minor
+
+    rel="$(uname -r)"
+    major="${rel%%.*}"
+    minor="${rel#*.}"
+    minor="${minor%%.*}"
+
+    want_major="${IOMMU_PASSTHROUGH_MIN_KERNEL%%.*}"
+    want_minor="${IOMMU_PASSTHROUGH_MIN_KERNEL#*.}"
+    want_minor="${want_minor%%.*}"
+
+    if ! [[ "${major}" =~ ^[0-9]+$ && "${minor}" =~ ^[0-9]+$ ]]; then
+        return 1
+    fi
+
+    if (( major < want_major )); then
+        return 0
+    fi
+    if (( major == want_major && minor < want_minor )); then
+        return 0
+    fi
+    return 1
+}
+
+# The effective iommu.passthrough value, or empty if unset.
+#
+# The token legitimately appears twice: the platform sets 1 and our drop-in appends 0.
+# The last occurrence is the one the kernel acted on, so grepping for =0 anywhere would
+# pass even when something later set it back to 1 -- the failure this check exists for.
+effective_passthrough() {
+    tr ' ' '\n' < "${PROC_CMDLINE}" \
+        | grep '^iommu\.passthrough=' \
+        | tail -1 \
+        | cut -d= -f2
+}
+
+# True when at least one IOMMU group uses a translating domain.
+#
+# sysfs rather than the dmesg "Default domain type:" line, which can wrap out of the ring
+# buffer. Only "at least one" is required: a driver may legitimately request an identity
+# domain for its own device.
+translation_active() {
+    local t
+    for t in "${IOMMU_GROUPS_DIR}"/*/type; do
+        [[ -r "${t}" ]] || continue
+        case "$(cat "${t}" 2>/dev/null)" in
+            DMA | DMA-FQ) return 0 ;;
+        esac
+    done
+    return 1
+}
+
+main() {
+    local policy effective
+
+    policy="$(iommu_policy)"
+
+    if ! iommu_enabled; then
+        echo "IOMMU passthrough workaround not enabled for this service/accelerator; nothing to verify"
+        return 0
+    fi
+
+    if [[ "${policy}" == "never" ]]; then
+        echo "IOMMU passthrough workaround switched off via CONFIGURE_IOMMU_PASSTHROUGH; nothing to verify"
+        return 0
+    fi
+
+    if [[ "${policy}" == "auto" ]] && ! kernel_predates_fix; then
+        echo "Kernel $(uname -r) is >= ${IOMMU_PASSTHROUGH_MIN_KERNEL}; passthrough is fine on this kernel, nothing to verify"
+        return 0
+    fi
+
+    effective="$(effective_passthrough)"
+
+    if [[ "${effective}" == "1" ]]; then
+        fail_not_applied \
+            "The booted kernel command line still resolves iommu.passthrough to 1. The last occurrence wins, so a file sorting after 99-iommu-passthrough.cfg in /etc/default/grub.d/ is overriding it, or the drop-in never reached grub.cfg. Check which entry GRUB_DEFAULT boots."
+    fi
+
+    if ! translation_active; then
+        fail_not_applied \
+            "No IOMMU group under ${IOMMU_GROUPS_DIR} is using a translating (DMA or DMA-FQ) domain, so the SMMU is still in bypass. 'dmesg | grep \"Default domain type\"' shows what the kernel resolved at boot."
+    fi
+
+    echo "Verified IOMMU translation is active after reboot (iommu.passthrough=${effective:-unset})"
+}
+
+# The only place an operator will look, so name the cause, the cost and the switch.
+fail_not_applied() {
+    cat <<EOF
+ERROR: The IOMMU passthrough workaround was requested but did not take effect on this node.
+
+  ${1}
+
+  Impact: on a kernel older than ${IOMMU_PASSTHROUGH_MIN_KERNEL}, arm-smmu-v3 cannot attach a PASID to an
+  identity domain, so nvidia_uvm's ATS/SVA bind fails with -E2BIG and NO CUDA context
+  can be created. cudaMalloc reports "CUDA-capable device(s) is/are busy or unavailable"
+  even with no processes on the GPUs. DCGM, the GPU operator validators and every GPU
+  workload fail together. Look for arm_smmu_write_ctx_desc in dmesg to confirm.
+
+  If this node should keep IOMMU passthrough (for example its kernel carries a backported
+  fix that the version check cannot see), set CONFIGURE_IOMMU_PASSTHROUGH=false in the
+  package env on the custom resource. That skips the change and this check.
+EOF
+    exit 1
+}
+
+main "$@"

--- a/tests/integration/nvidia_tuned/fakes/uname
+++ b/tests/integration/nvidia_tuned/fakes/uname
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Test double for uname. Reports FAKE_UNAME_R for `uname -r` so tests can pin the kernel
+# version the IOMMU passthrough policy sees. Every other invocation, and any invocation
+# with FAKE_UNAME_R unset, defers to the real binary.
+
+set -euo pipefail
+
+if [[ "${1:-}" == "-r" && -n "${FAKE_UNAME_R:-}" ]]; then
+    echo "${FAKE_UNAME_R}"
+    exit 0
+fi
+
+exec /usr/bin/uname "$@"

--- a/tests/integration/nvidia_tuned/test_host_setup.py
+++ b/tests/integration/nvidia_tuned/test_host_setup.py
@@ -765,7 +765,7 @@ def test_iommu_passthrough_is_a_noop_on_a_fixed_kernel(node):
     new = on_kernel(NEW_KERNEL)
 
     assert step(node, "configure_iommu_passthrough.sh", new) == 0, output(node)
-    assert said(node, "nothing to do"), output(node)
+    assert said(node, "passthrough is fine here"), output(node)
     assert not exists(node, IOMMU_DROPIN)
 
     for check in ("configure_iommu_passthrough_check.sh",
@@ -930,3 +930,41 @@ def test_iommu_passthrough_failure_message_names_cause_impact_and_remedy(node):
     assert said(node, "arm_smmu_write_ctx_desc"), output(node)
     # Remedy: the documented opt-out.
     assert said(node, "CONFIGURE_IOMMU_PASSTHROUGH=false"), output(node)
+
+
+def test_iommu_passthrough_off_removes_a_previously_written_dropin(node):
+    """`false` has to restore passthrough, not just stop maintaining the drop-in.
+
+    A stale drop-in still contributes iommu.passthrough=0 at the next boot, so leaving it
+    in place would make the documented escape hatch unable to do the thing it documents.
+    """
+    configure(node, **OCI_GB300)
+
+    assert step(node, "configure_iommu_passthrough.sh", on_kernel(OLD_KERNEL)) == 0
+    assert exists(node, IOMMU_DROPIN)
+
+    off = on_kernel(OLD_KERNEL, CONFIGURE_IOMMU_PASSTHROUGH="false")
+    assert step(node, "configure_iommu_passthrough.sh", off) == 0, output(node)
+    assert said(node, "reboot is required to restore"), output(node)
+    assert not exists(node, IOMMU_DROPIN)
+
+
+def test_iommu_passthrough_removes_the_dropin_after_a_kernel_upgrade(node):
+    """A node upgraded past the threshold must not keep the workaround pinned on."""
+    configure(node, **OCI_GB300)
+
+    assert step(node, "configure_iommu_passthrough.sh", on_kernel(OLD_KERNEL)) == 0
+    assert exists(node, IOMMU_DROPIN)
+
+    assert step(node, "configure_iommu_passthrough.sh", on_kernel(NEW_KERNEL)) == 0
+    assert said(node, "reboot is required to restore"), output(node)
+    assert not exists(node, IOMMU_DROPIN)
+
+
+def test_iommu_passthrough_removal_is_idempotent(node):
+    """Standing down on a node that never had the drop-in must not claim it removed one."""
+    configure(node, **OCI_GB300)
+    off = on_kernel(OLD_KERNEL, CONFIGURE_IOMMU_PASSTHROUGH="false")
+
+    assert step(node, "configure_iommu_passthrough.sh", off) == 0, output(node)
+    assert not said(node, "Removed"), output(node)

--- a/tests/integration/nvidia_tuned/test_host_setup.py
+++ b/tests/integration/nvidia_tuned/test_host_setup.py
@@ -968,3 +968,20 @@ def test_iommu_passthrough_removal_is_idempotent(node):
 
     assert step(node, "configure_iommu_passthrough.sh", off) == 0, output(node)
     assert not said(node, "Removed"), output(node)
+
+
+def test_iommu_passthrough_post_interrupt_check_rejects_an_absent_value(node):
+    """An absent token means nothing this package wrote reached the booted kernel.
+
+    The drop-in sets iommu.passthrough explicitly, so its absence is a drop-in that never
+    applied. Accepting it because the kernel happened to default to a translating domain
+    would report a broken deployment as fixed.
+    """
+    configure(node, **OCI_GB300)
+    env = on_kernel(OLD_KERNEL, **booted(node, "root=x quiet", "DMA-FQ"))
+
+    assert step(node, "post_interrupt_iommu_passthrough_check.sh", env) != 0
+    assert said(node, "carries no iommu.passthrough argument"), output(node)
+    # Still reaches the shared diagnostic rather than exiting early.
+    assert said(node, "NO CUDA context"), output(node)
+    assert said(node, "CONFIGURE_IOMMU_PASSTHROUGH=false"), output(node)

--- a/tests/integration/nvidia_tuned/test_host_setup.py
+++ b/tests/integration/nvidia_tuned/test_host_setup.py
@@ -22,14 +22,15 @@ Tests for the nvidia-tuned host setup steps added for OCI GB300.
 Covers:
 - install_rdma_vfs_ready.sh, its config, post-interrupt, and uninstall checks
 - configure_pcie_acs.sh, its config and post-interrupt checks
+- configure_iommu_passthrough.sh, its config and post-interrupt checks
 - the bundled wait-rdma-vfs.sh helper
 
 Both steps self-gate on bundled assets resolved from the service and accelerator
 configmaps, so the no-op path for every other service/accelerator pair is covered too.
 
 These steps do not depend on the OS, so they run against a single base image rather
-than the package TEST_MATRIX. Real systemctl, rdma_topo, and update-grub are replaced
-by the test doubles in fakes/.
+than the package TEST_MATRIX. Real systemctl, rdma_topo, update-grub, and uname are
+replaced by the test doubles in fakes/.
 
 Assertions go through exit codes rather than captured text: a step's output is written
 to a file in the container and matched there with grep. The container exec API returns
@@ -55,6 +56,13 @@ OUTPUT_FILE = "/tmp/step-output"
 UNIT_DEST = "/etc/systemd/system/rdma-vfs-ready.service"
 HELPER_DEST = "/usr/local/sbin/wait-rdma-vfs.sh"
 ACS_DROPIN = "/etc/default/grub.d/config-acs.cfg"
+IOMMU_DROPIN = "/etc/default/grub.d/99-iommu-passthrough.cfg"
+FAKE_CMDLINE = "/tmp/fake-cmdline"
+FAKE_IOMMU_GROUPS = "/tmp/fake-iommu-groups"
+
+# Either side of the 6.11 threshold, where arm-smmu-v3 gained S1DSS_BYPASS.
+OLD_KERNEL = "6.8.0-1060-generic"
+NEW_KERNEL = "6.14.0-1015-generic"
 SYSTEMCTL_CALLS = "/tmp/fake-systemctl/calls"
 
 BUNDLED_DIR = "/skyhook-package/profiles/service/oci/rdma-vfs-ready-gb300"
@@ -682,3 +690,243 @@ def test_pcie_acs_rejects_unreadable_acs_state(node):
     # And it must not be reported as verified.
     assert step(node, "post_interrupt_pcie_acs_check.sh", unreadable) != 0
     assert said(node, "did not take effect on this node"), output(node)
+
+
+# ---------------------------------------------------------------------------
+# configure_iommu_passthrough.sh
+#
+# The policy turns on `uname -r`, so these pin it through the uname fake rather than
+# inheriting whatever kernel the test host happens to run.
+# ---------------------------------------------------------------------------
+
+
+def on_kernel(version: str, **extra) -> dict:
+    """Step env with the reported kernel version pinned."""
+    return {"FAKE_UNAME_R": version, **extra}
+
+
+def booted(node: DockerTestRunner, cmdline: str, *group_types: str) -> dict:
+    """Stage a fake booted state and return the env that points the check at it.
+
+    cmdline is written verbatim so a test can place iommu.passthrough more than once;
+    group_types become one sysfs group each, which is how translation is detected.
+    """
+    cmds = [f"printf '%s\\n' {shell_quote(cmdline)} > {FAKE_CMDLINE}",
+            f"rm -rf {FAKE_IOMMU_GROUPS}"]
+    for index, group_type in enumerate(group_types):
+        cmds.append(f"mkdir -p {FAKE_IOMMU_GROUPS}/{index}")
+        cmds.append(
+            f"printf '%s\\n' {shell_quote(group_type)} > {FAKE_IOMMU_GROUPS}/{index}/type"
+        )
+    assert sh(node, " && ".join(cmds)) == 0
+    return {"PROC_CMDLINE": FAKE_CMDLINE, "IOMMU_GROUPS_DIR": FAKE_IOMMU_GROUPS}
+
+
+@pytest.mark.parametrize("configmaps", OTHER_SHAPES, ids=OTHER_SHAPE_IDS)
+def test_iommu_passthrough_is_a_noop_without_the_opt_in_marker(node, configmaps):
+    configure(node, **configmaps)
+    old = on_kernel(OLD_KERNEL)
+
+    assert step(node, "configure_iommu_passthrough.sh", old) == 0, output(node)
+    assert said(node, "nothing to do"), output(node)
+    assert not exists(node, IOMMU_DROPIN)
+
+    for check in ("configure_iommu_passthrough_check.sh",
+                  "post_interrupt_iommu_passthrough_check.sh"):
+        assert step(node, check, old) == 0, output(node)
+        assert said(node, "nothing to verify"), output(node)
+
+
+def test_iommu_passthrough_writes_the_dropin_on_an_affected_kernel(node):
+    configure(node, **OCI_GB300)
+
+    assert step(node, "configure_iommu_passthrough.sh", on_kernel(OLD_KERNEL)) == 0
+    assert said(node, "reboot is required"), output(node)
+    assert contains(node, IOMMU_DROPIN, "iommu.passthrough=0")
+    assert exists(node, "/tmp/fake-grub/update-grub-ran")
+
+
+def test_iommu_passthrough_appends_rather_than_replacing(node):
+    """The drop-in must supersede an earlier producer without depending on one.
+
+    It contributes by appending to $GRUB_CMDLINE_LINUX, so it is correct whether or not
+    the platform ships a drop-in of its own, and sorts last so its value is the one the
+    kernel acts on.
+    """
+    configure(node, **OCI_GB300)
+
+    assert step(node, "configure_iommu_passthrough.sh", on_kernel(OLD_KERNEL)) == 0
+    assert contains(node, IOMMU_DROPIN, 'GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX')
+
+
+def test_iommu_passthrough_is_a_noop_on_a_fixed_kernel(node):
+    """At or above the threshold the kernel handles PASID on an identity domain."""
+    configure(node, **OCI_GB300)
+    new = on_kernel(NEW_KERNEL)
+
+    assert step(node, "configure_iommu_passthrough.sh", new) == 0, output(node)
+    assert said(node, "nothing to do"), output(node)
+    assert not exists(node, IOMMU_DROPIN)
+
+    for check in ("configure_iommu_passthrough_check.sh",
+                  "post_interrupt_iommu_passthrough_check.sh"):
+        assert step(node, check, new) == 0, output(node)
+
+
+def test_iommu_passthrough_is_idempotent_across_config_passes(node):
+    configure(node, **OCI_GB300)
+    old = on_kernel(OLD_KERNEL)
+
+    assert step(node, "configure_iommu_passthrough.sh", old) == 0, output(node)
+    assert sh(node, f"cp {IOMMU_DROPIN} /tmp/iommu-dropin.first") == 0
+    assert step(node, "configure_iommu_passthrough.sh", old) == 0, output(node)
+
+    assert said(node, "already current"), output(node)
+    assert same(node, "/tmp/iommu-dropin.first", IOMMU_DROPIN)
+
+
+def test_iommu_passthrough_rewrites_a_stale_dropin(node):
+    """A drop-in left by an older package version is corrected, not silently kept."""
+    configure(node, **OCI_GB300)
+    assert sh(node, "mkdir -p /etc/default/grub.d") == 0
+    assert sh(node, f"printf '%s\\n' '# stale' > {IOMMU_DROPIN}") == 0
+
+    assert step(node, "configure_iommu_passthrough.sh", on_kernel(OLD_KERNEL)) == 0
+    assert contains(node, IOMMU_DROPIN, "iommu.passthrough=0")
+
+
+@pytest.mark.parametrize("value", ["false", "FALSE", "0", "no", "off"])
+def test_iommu_passthrough_can_be_switched_off_by_the_operator(node, value):
+    """The escape hatch for a kernel carrying a backported fix uname cannot see."""
+    configure(node, **OCI_GB300)
+    off = on_kernel(OLD_KERNEL, CONFIGURE_IOMMU_PASSTHROUGH=value)
+
+    assert step(node, "configure_iommu_passthrough.sh", off) == 0, output(node)
+    assert said(node, "switched off"), output(node)
+    assert not exists(node, IOMMU_DROPIN)
+
+    # Both checks stand down, so a switched-off node never fails post-interrupt.
+    for check in ("configure_iommu_passthrough_check.sh",
+                  "post_interrupt_iommu_passthrough_check.sh"):
+        assert step(node, check, off) == 0, output(node)
+        assert said(node, "switched off"), output(node)
+
+
+@pytest.mark.parametrize("value", ["true", "TRUE", "1", "yes", "on"])
+def test_iommu_passthrough_can_be_forced_on_a_fixed_kernel(node, value):
+    """`true` overrides the version check, for a kernel auto reads wrongly."""
+    configure(node, **OCI_GB300)
+
+    rc = step(node, "configure_iommu_passthrough.sh",
+              on_kernel(NEW_KERNEL, CONFIGURE_IOMMU_PASSTHROUGH=value))
+    assert rc == 0, output(node)
+    assert said(node, "reboot is required"), output(node)
+    assert contains(node, IOMMU_DROPIN, "iommu.passthrough=0")
+
+
+def test_iommu_passthrough_treats_an_unparseable_kernel_as_new_enough(node):
+    """Applying a boot-affecting change to an unknown platform is the worse failure."""
+    configure(node, **OCI_GB300)
+
+    assert step(node, "configure_iommu_passthrough.sh", on_kernel("not-a-version")) == 0
+    assert said(node, "cannot parse kernel version"), output(node)
+    assert not exists(node, IOMMU_DROPIN)
+
+
+def test_iommu_passthrough_config_check_fails_when_nothing_was_written(node):
+    configure(node, **OCI_GB300)
+
+    assert step(node, "configure_iommu_passthrough_check.sh", on_kernel(OLD_KERNEL)) != 0
+    assert said(node, "no bootloader drop-in"), output(node)
+
+
+@pytest.mark.parametrize(
+    ("dropin", "accepted"),
+    [
+        ('GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX iommu.passthrough=0"', True),
+        ("iommu.passthrough=0", True),
+        ("\tiommu.passthrough=0", True),
+        ("# iommu.passthrough=0", False),
+        ("  # iommu.passthrough=0", False),
+        ('GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX" # iommu.passthrough=0', False),
+        ("# example only, nothing active here", False),
+    ],
+    ids=[
+        "assignment",
+        "bare",
+        "tab-indented",
+        "comment",
+        "indented-comment",
+        "inline-comment",
+        "no-token",
+    ],
+)
+def test_iommu_passthrough_config_check_only_accepts_an_active_setting(
+    node, dropin, accepted
+):
+    """A commented example must not satisfy the pre-reboot check, but indentation must."""
+    configure(node, **OCI_GB300)
+    assert sh(node, "mkdir -p /etc/default/grub.d") == 0
+    assert sh(node, f"printf '%s\\n' {shell_quote(dropin)} > {IOMMU_DROPIN}") == 0
+
+    rc = step(node, "configure_iommu_passthrough_check.sh", on_kernel(OLD_KERNEL))
+    if accepted:
+        assert rc == 0, output(node)
+        assert said(node, "pending reboot"), output(node)
+    else:
+        assert rc != 0, output(node)
+        assert said(node, "does not contain an active"), output(node)
+
+
+def test_iommu_passthrough_post_interrupt_check_accepts_a_translated_node(node):
+    configure(node, **OCI_GB300)
+    env = on_kernel(OLD_KERNEL,
+                    **booted(node, "root=x iommu.passthrough=1 quiet iommu.passthrough=0",
+                             "DMA-FQ", "DMA-FQ"))
+
+    assert step(node, "post_interrupt_iommu_passthrough_check.sh", env) == 0, output(node)
+    assert said(node, "translation is active"), output(node)
+
+
+def test_iommu_passthrough_post_interrupt_check_reads_the_last_cmdline_value(node):
+    """The token legitimately appears twice; only the last one is what the kernel used.
+
+    A drop-in that sorts before another producer leaves iommu.passthrough=1 in effect
+    while =0 is still present on the command line. Matching the token anywhere would
+    report that node as fixed, which is the failure this check exists to catch.
+    """
+    configure(node, **OCI_GB300)
+    env = on_kernel(OLD_KERNEL,
+                    **booted(node, "root=x iommu.passthrough=0 quiet iommu.passthrough=1",
+                             "identity", "identity"))
+
+    assert step(node, "post_interrupt_iommu_passthrough_check.sh", env) != 0
+    assert said(node, "still resolves iommu.passthrough to 1"), output(node)
+
+
+def test_iommu_passthrough_post_interrupt_check_requires_translation_to_be_live(node):
+    """A correct command line is not evidence on its own; the SMMU must have acted."""
+    configure(node, **OCI_GB300)
+    env = on_kernel(OLD_KERNEL,
+                    **booted(node, "root=x iommu.passthrough=1 quiet iommu.passthrough=0",
+                             "identity", "identity"))
+
+    assert step(node, "post_interrupt_iommu_passthrough_check.sh", env) != 0
+    assert said(node, "still in bypass"), output(node)
+
+
+def test_iommu_passthrough_failure_message_names_cause_impact_and_remedy(node):
+    """Whoever investigates the failure must not need to read the source to act."""
+    configure(node, **OCI_GB300)
+    env = on_kernel(OLD_KERNEL,
+                    **booted(node, "root=x iommu.passthrough=1", "identity"))
+
+    assert step(node, "post_interrupt_iommu_passthrough_check.sh", env) != 0
+
+    # Cause: the workaround did not reach the booted kernel.
+    assert said(node, "did not take effect on this node"), output(node)
+    # Impact: no CUDA context can be created, and where to look to confirm.
+    assert said(node, "NO CUDA context"), output(node)
+    assert said(node, "arm_smmu_write_ctx_desc"), output(node)
+    # Remedy: the documented opt-out.
+    assert said(node, "CONFIGURE_IOMMU_PASSTHROUGH=false"), output(node)


### PR DESCRIPTION
## What

Adds a `configure-iommu-passthrough` step to `nvidia-tuned`, needed to run ACS + DMA-BUF on kernels older than 6.11.

`arm-smmu-v3` before 6.11 cannot attach a PASID to an identity domain. Under `iommu.passthrough=1` the master's context descriptor table is never allocated (`arm_smmu_alloc_cd_tables()` is only reached for a stage-1 translating domain), so `cd_table->s1cdmax` stays 0 and `nvidia_uvm`'s ATS/SVA bind trips:

```
WARN_ON(ssid >= (1 << cd_table->s1cdmax))   ->  -E2BIG
  arm_smmu_write_ctx_desc
  arm_smmu_sva_set_dev_pasid
  iommu_sva_bind_device
  uvm_ats_bind_gpu                 [nvidia_uvm]
  uvm_va_space_register_gpu_va_space [nvidia_uvm]
```

The user-visible effect is that **no CUDA context can be created at all when ACS is enabled**: `cudaMalloc` reports the GPUs as busy on a node with nothing running on them, so DCGM, the GPU operator validators and every workload fail together. 

Setting `iommu.passthrough=0` restores translating (DMA-FQ) domains, the CD table is allocated, the bind succeeds, and CUDA, GPUDirect RDMA and the DMA-BUF path the ACS correction sets up all work.

## Threshold

Upstream fixed this in two steps: 6.10 made CD tables allocate-on-demand, and 6.11 added `STRTAB_STE_1_S1DSS_BYPASS` (PASID on an identity STE). 6.11 is the threshold.

## Behaviour

- Gated on `profiles/service/${service}/iommu-passthrough-${accelerator}.enabled`, so pairs without the marker are a no-op. Today only `oci` + `gb300`.
- One operator knob, `CONFIGURE_IOMMU_PASSTHROUGH`: `auto` (default, apply below 6.11), `true` (always), `false` (never, skips the checks). Mirrors `CONFIGURE_PCIE_ACS`.
- `auto` reads `uname -r`, and vendor kernels backport, so it can guess wrong in both directions. Detecting a backported fix requires the GPU driver to be loaded, which deadlocks bringup, so the explicit values are the escape hatch.
- Writes `/etc/default/grub.d/99-iommu-passthrough.cfg`. Appends to `$GRUB_CMDLINE_LINUX` and sorts last, so it supersedes an earlier producer **without depending on one existing**.
- Independent of the ACS correction; both are active together.

## Notes for review

- **Duplicated helpers across the three scripts** (`iommu_enabled`, `iommu_policy`, `kernel_predates_fix`) are deliberate: this mirrors `acs_enabled`/`acs_requested` in the ACS scripts. Each step runs as a standalone process.
- **The post-interrupt check reads the *last* `iommu.passthrough` value** on the command line rather than grepping for the token. The value legitimately appears twice (platform sets 1, this drop-in appends 0); it is an `early_param` and `do_early_param()` runs the handler per occurrence in order, so only the last applies. A `grep iommu.passthrough=0` would pass even when something later set it back to 1.
- **Translation is verified via sysfs group type**, not the dmesg `Default domain type:` line, which can wrap out of the ring buffer.
- **Tests** cover marker gating, the version policy either side of the threshold, explicit true/false overrides, idempotent re-runs, stale drop-in replacement, an unparseable kernel version, the active-vs-commented matcher, drop-in removal when the policy stands down, and the three post-interrupt outcomes. A `uname` test double pins the kernel version the policy sees.
- **No uninstall step**, so the drop-in survives package removal. Same gap as `configure_pcie_acs.sh`; flagging it rather than hiding it.

## Testing

Verified on affected hardware: a node that could not create a CUDA context came up healthy after the change, with DMA-BUF active in a multi-node NCCL all_reduce and collective bandwidth in line with an unaffected node. The ACS correction remained in place throughout.
