### PR TITLE
feat(nvidia-tuned): Disable IOMMU passthrough on kernels needing it for ACS + DMA-BUF

### DIFF
--- a/nvidia-tuned/README.md
+++ b/nvidia-tuned/README.md
@@ -286,6 +286,14 @@ host-level steps do need a reboot:
   `pci=config_acs=`; on a node whose kernel does not, set `CONFIGURE_PCIE_ACS=false`
   (see the environment variables below), keep `nvidia_peermem` loaded, and keep
   `NCCL_DMABUF_ENABLE=0` set.
+- **IOMMU passthrough on old kernels.** Needed to run ACS + DMA-BUF on kernels older
+  than 6.11. OCI ships `iommu.passthrough=1`, and arm-smmu-v3 before 6.11 cannot attach
+  a PASID to an identity domain, so `nvidia_uvm`'s ATS/SVA bind fails with `-E2BIG` and
+  **no CUDA context can be created at all** — `cudaMalloc` reports the GPUs as busy on an
+  idle node. The `configure-iommu-passthrough` step writes a
+  `/etc/default/grub.d/99-iommu-passthrough.cfg` drop-in setting `iommu.passthrough=0`,
+  restoring translating domains and with them CUDA, GPUDirect RDMA and DMA-BUF. Defaults
+  to `auto` (apply below 6.11). Independent of the ACS correction; both can be active.
 - **RDMA VF boot gate.** The `install-rdma-vfs-ready` step installs a
   `rdma-vfs-ready.service` unit that orders before `kubelet.service` and waits for the
   Oracle Cloud Agent to create the RDMA VFs. It is a boot-ordering gate, so it only has
@@ -357,6 +365,7 @@ Both steps are no-ops for every other `service`/`accelerator` pair, so existing 
 |----------|----------|---------|-------------|
 | `TOPO_PATH` | No | `/etc/nccl/topo.xml` | Absolute host path the bundled NCCL topology file is written to. Only used when the configured `service`/`accelerator` pair ships one (today `oci` + `gb300`); otherwise the step is a no-op. Point `NCCL_TOPO_FILE` at the same path in your workloads. |
 | `CONFIGURE_PCIE_ACS` | No | `true` | Set to `false` to skip the PCIe ACS correction and its checks. Only relevant to a `service`/`accelerator` pair that opts in (today `oci` + `gb300`). Use this on nodes whose kernel does not honour `pci=config_acs=`, where the correction cannot take effect and the post-interrupt check would otherwise fail the node. |
+| `CONFIGURE_IOMMU_PASSTHROUGH` | No | `auto` | Controls the IOMMU passthrough workaround for kernels whose arm-smmu-v3 cannot attach a PASID to an identity domain. `auto` applies it only when the running kernel is older than 6.11; `true` always applies it; `false` never does and skips the checks. Only relevant to a `service`/`accelerator` pair that opts in (today `oci` + `gb300`). Set `false` on a node whose kernel carries a backported fix that the version check cannot see. |
 | `APT_ALLOW_INDEX_FAILURE` | No | `true` | Inherited from the `tuned` base package. Lets `apt update` fail without failing the install step, so one unreachable third-party repo in `/etc/apt/sources.list.d` cannot block the package. Set to `false` to restore strict behavior. The `apt install` that follows is unaffected and still fails if the package is genuinely unavailable. |
 
 ## Adding OS-Specific Overrides

--- a/nvidia-tuned/README.md
+++ b/nvidia-tuned/README.md
@@ -250,7 +250,7 @@ spec:
   packages:
     nvidia-tuned:
       image: ghcr.io/nvidia/nodewright-packages/nvidia-tuned
-      version: 0.7.0
+      version: 0.8.0
       interrupt:
         type: reboot
       env:
@@ -289,11 +289,14 @@ host-level steps do need a reboot:
 - **IOMMU passthrough on old kernels.** Needed to run ACS + DMA-BUF on kernels older
   than 6.11. OCI ships `iommu.passthrough=1`, and arm-smmu-v3 before 6.11 cannot attach
   a PASID to an identity domain, so `nvidia_uvm`'s ATS/SVA bind fails with `-E2BIG` and
-  **no CUDA context can be created at all** — `cudaMalloc` reports the GPUs as busy on an
+  **no CUDA context can be created at all**: `cudaMalloc` reports the GPUs as busy on an
   idle node. The `configure-iommu-passthrough` step writes a
   `/etc/default/grub.d/99-iommu-passthrough.cfg` drop-in setting `iommu.passthrough=0`,
   restoring translating domains and with them CUDA, GPUDirect RDMA and DMA-BUF. Defaults
-  to `auto` (apply below 6.11). Independent of the ACS correction; both can be active.
+  to `auto` (apply below 6.11). When the policy stops applying, because the node was
+  switched off or its kernel was upgraded past the threshold, the drop-in is removed and
+  GRUB regenerated, so passthrough comes back on the next boot. Independent of the ACS
+  correction; both can be active.
 - **RDMA VF boot gate.** The `install-rdma-vfs-ready` step installs a
   `rdma-vfs-ready.service` unit that orders before `kubelet.service` and waits for the
   Oracle Cloud Agent to create the RDMA VFs. It is a boot-ordering gate, so it only has

--- a/nvidia-tuned/README.md
+++ b/nvidia-tuned/README.md
@@ -295,8 +295,10 @@ host-level steps do need a reboot:
   restoring translating domains and with them CUDA, GPUDirect RDMA and DMA-BUF. Defaults
   to `auto` (apply below 6.11). When the policy stops applying, because the node was
   switched off or its kernel was upgraded past the threshold, the drop-in is removed and
-  GRUB regenerated, so passthrough comes back on the next boot. Independent of the ACS
-  correction; both can be active.
+  GRUB regenerated, so passthrough comes back on the next boot. It is scoped to affected
+  kernels rather than applied everywhere because translating domains cost DMA performance,
+  which is why passthrough is set in the first place; on a kernel with the fix there is no
+  benefit to pay for. Independent of the ACS correction; both can be active.
 - **RDMA VF boot gate.** The `install-rdma-vfs-ready` step installs a
   `rdma-vfs-ready.service` unit that orders before `kubelet.service` and waits for the
   Oracle Cloud Agent to create the RDMA VFs. It is a boot-ordering gate, so it only has

--- a/nvidia-tuned/RELEASE_NOTES.md
+++ b/nvidia-tuned/RELEASE_NOTES.md
@@ -20,6 +20,26 @@ example is not itself picked up as release notes):
     - Notable behavior change worth calling out.
 -->
 
+## 0.8.0
+
+Adds an IOMMU passthrough workaround needed to run ACS + DMA-BUF on kernels older than
+6.11, gated on `oci` + `gb300` like the PCIe ACS correction.
+
+OCI ships `iommu.passthrough=1`, and arm-smmu-v3 before 6.11 cannot attach a PASID to an
+identity domain, so `nvidia_uvm`'s ATS/SVA bind fails with `-E2BIG` and no CUDA context
+can be created — `cudaMalloc` reports the GPUs as busy on an idle node, taking DCGM, the
+GPU operator validators and every workload with it. The new `configure-iommu-passthrough`
+step writes a `99-iommu-passthrough.cfg` grub drop-in setting `iommu.passthrough=0`.
+
+Defaults to `CONFIGURE_IOMMU_PASSTHROUGH=auto`, applying only on kernels older than
+6.11. Vendor kernels backport, so `auto` can guess wrong either way; set `false` to keep
+passthrough or `true` to force the change.
+
+Upgrade note: changes the kernel command line, so it takes effect on the next boot via
+the `interrupt: {type: reboot}` this package already requires. Nodes at or above the
+threshold are unaffected. Translating domains cost some DMA performance; the trade is
+against those nodes being unable to run CUDA at all.
+
 ## 0.7.2
 
 Picks up tuned 1.3.2, which stops a single unreachable or stale apt repo from

--- a/nvidia-tuned/RELEASE_NOTES.md
+++ b/nvidia-tuned/RELEASE_NOTES.md
@@ -44,6 +44,19 @@ the `interrupt: {type: reboot}` this package already requires. Nodes at or above
 threshold are unaffected. Translating domains cost some DMA performance; the trade is
 against those nodes being unable to run CUDA at all.
 
+Also fixes the Spectrum-X congestion control uninstall check rejecting a node whose units were
+already removed, which blocked every nvidia-tuned upgrade on an affected node.
+
+Removing the template unit file is what makes each instance `not-found`, and systemd keeps
+those stubs enumerated under `systemctl list-units --all` until they are garbage collected.
+The device units udev created still reference them, so they survive `daemon-reload`, and
+`reset-failed` does not clear them because they are inactive/dead rather than failed. The
+check counted any listed instance, so a node that had been cleaned up correctly could never
+pass, and the uninstall step retried until it backed off.
+
+The check now ignores instances whose LOAD column reads `not-found`. A unit that is still
+loaded remains a failure.
+
 ## 0.7.2
 
 Picks up tuned 1.3.2, which stops a single unreachable or stale apt repo from

--- a/nvidia-tuned/RELEASE_NOTES.md
+++ b/nvidia-tuned/RELEASE_NOTES.md
@@ -37,7 +37,9 @@ passthrough or `true` to force the change.
 
 Setting `false`, or upgrading a node past the threshold under `auto`, removes a drop-in
 this package previously wrote and regenerates GRUB, so passthrough returns on the next
-boot rather than staying pinned off.
+boot rather than staying pinned off. Uninstalling the package removes it too, unlike the
+PCIe ACS drop-in, which corrects a hardware misconfiguration and is deliberately left in
+place.
 
 Upgrade note: changes the kernel command line, so it takes effect on the next boot via
 the `interrupt: {type: reboot}` this package already requires. Nodes at or above the

--- a/nvidia-tuned/RELEASE_NOTES.md
+++ b/nvidia-tuned/RELEASE_NOTES.md
@@ -27,13 +27,17 @@ Adds an IOMMU passthrough workaround needed to run ACS + DMA-BUF on kernels olde
 
 OCI ships `iommu.passthrough=1`, and arm-smmu-v3 before 6.11 cannot attach a PASID to an
 identity domain, so `nvidia_uvm`'s ATS/SVA bind fails with `-E2BIG` and no CUDA context
-can be created — `cudaMalloc` reports the GPUs as busy on an idle node, taking DCGM, the
+can be created: `cudaMalloc` reports the GPUs as busy on an idle node, taking DCGM, the
 GPU operator validators and every workload with it. The new `configure-iommu-passthrough`
 step writes a `99-iommu-passthrough.cfg` grub drop-in setting `iommu.passthrough=0`.
 
 Defaults to `CONFIGURE_IOMMU_PASSTHROUGH=auto`, applying only on kernels older than
 6.11. Vendor kernels backport, so `auto` can guess wrong either way; set `false` to keep
 passthrough or `true` to force the change.
+
+Setting `false`, or upgrading a node past the threshold under `auto`, removes a drop-in
+this package previously wrote and regenerates GRUB, so passthrough returns on the next
+boot rather than staying pinned off.
 
 Upgrade note: changes the kernel command line, so it takes effect on the next boot via
 the `interrupt: {type: reboot}` this package already requires. Nodes at or above the

--- a/nvidia-tuned/config.json
+++ b/nvidia-tuned/config.json
@@ -1,7 +1,7 @@
 {
     "schema_version": "v1",
     "package_name": "nvidia_tuned",
-    "package_version": "0.7.2",
+    "package_version": "0.8.0",
     "expected_config_files": [
         "accelerator"
     ],
@@ -188,6 +188,18 @@
                 "upgrade_step": false
             },
             {
+                "name": "configure-iommu-passthrough",
+                "path": "configure_iommu_passthrough.sh",
+                "arguments": [],
+                "returncodes": [
+                    0
+                ],
+                "on_host": true,
+                "env": {},
+                "idempotence": false,
+                "upgrade_step": false
+            },
+            {
                 "name": "configure-spcx-cc",
                 "path": "configure_spcx_cc.sh",
                 "arguments": [],
@@ -262,6 +274,18 @@
                 "upgrade_step": false
             },
             {
+                "name": "configure-iommu-passthrough-check",
+                "path": "configure_iommu_passthrough_check.sh",
+                "arguments": [],
+                "returncodes": [
+                    0
+                ],
+                "on_host": true,
+                "env": {},
+                "idempotence": true,
+                "upgrade_step": false
+            },
+            {
                 "name": "configure-spcx-cc-check",
                 "path": "configure_spcx_cc_check.sh",
                 "arguments": [],
@@ -302,6 +326,18 @@
             {
                 "name": "post-interrupt-pcie-acs-check",
                 "path": "post_interrupt_pcie_acs_check.sh",
+                "arguments": [],
+                "returncodes": [
+                    0
+                ],
+                "on_host": true,
+                "env": {},
+                "idempotence": true,
+                "upgrade_step": false
+            },
+            {
+                "name": "post-interrupt-iommu-passthrough-check",
+                "path": "post_interrupt_iommu_passthrough_check.sh",
                 "arguments": [],
                 "returncodes": [
                     0

--- a/nvidia-tuned/config.json
+++ b/nvidia-tuned/config.json
@@ -32,6 +32,18 @@
                 "upgrade_step": false
             },
             {
+                "name": "uninstall-iommu-passthrough",
+                "path": "uninstall_iommu_passthrough.sh",
+                "arguments": [],
+                "returncodes": [
+                    0
+                ],
+                "on_host": true,
+                "env": {},
+                "idempotence": true,
+                "upgrade_step": false
+            },
+            {
                 "name": "uninstall",
                 "path": "uninstall_tuned.sh",
                 "arguments": [],
@@ -60,6 +72,18 @@
             {
                 "name": "uninstall-spcx-cc-check",
                 "path": "uninstall_spcx_cc_check.sh",
+                "arguments": [],
+                "returncodes": [
+                    0
+                ],
+                "on_host": true,
+                "env": {},
+                "idempotence": true,
+                "upgrade_step": false
+            },
+            {
+                "name": "uninstall-iommu-passthrough-check",
+                "path": "uninstall_iommu_passthrough_check.sh",
                 "arguments": [],
                 "returncodes": [
                     0

--- a/nvidia-tuned/profiles/service/oci/iommu-passthrough-gb300.enabled
+++ b/nvidia-tuned/profiles/service/oci/iommu-passthrough-gb300.enabled
@@ -1,0 +1,7 @@
+# Marker: opt this service/accelerator pair in to the IOMMU passthrough workaround run
+# by skyhook_dir/configure_iommu_passthrough.sh. The file is a switch; its contents are
+# ignored.
+#
+# Needed to run ACS + DMA-BUF on kernels older than 6.11, whose arm-smmu-v3 cannot
+# attach a PASID to an identity domain. Requires a reboot, so a custom resource
+# selecting this pair must declare `interrupt: {type: reboot}`.

--- a/nvidia-tuned/skyhook_dir/configure_iommu_passthrough.sh
+++ b/nvidia-tuned/skyhook_dir/configure_iommu_passthrough.sh
@@ -27,6 +27,11 @@
 # Upstream: 6.10 made CD tables allocate-on-demand, 6.11 added S1DSS_BYPASS (PASID on an
 # identity STE). 6.11 is the threshold.
 #
+# Scoped to affected kernels rather than applied everywhere because translating domains
+# cost DMA performance, which is why the platform sets passthrough in the first place. On
+# a kernel with the fix there is nothing to buy with that cost, so applying it there would
+# be a straight regression on nodes that are already healthy.
+#
 # Gated on ${SKYHOOK_DIR}/profiles/service/${service}/iommu-passthrough-${accelerator}.enabled,
 # so pairs without the marker are a no-op. CONFIGURE_IOMMU_PASSTHROUGH picks the policy:
 # auto (default, apply below IOMMU_PASSTHROUGH_MIN_KERNEL), true (always), false (never).

--- a/nvidia-tuned/skyhook_dir/configure_iommu_passthrough.sh
+++ b/nvidia-tuned/skyhook_dir/configure_iommu_passthrough.sh
@@ -50,13 +50,14 @@ IOMMU_PASSTHROUGH_MIN_KERNEL="${IOMMU_PASSTHROUGH_MIN_KERNEL:-6.11}"
 # iommu.passthrough is an early_param and do_early_param() runs the handler on each
 # occurrence in order, so the last value wins. Appending rather than rewriting keeps this
 # correct whether or not the platform ships its own drop-in.
-read -r -d '' DROPIN_CONTENT <<'EOF' || true
+DROPIN_CONTENT="$(cat <<'EOF'
 # Managed by the nvidia-tuned Skyhook package. Do not edit.
 #
 # arm-smmu-v3 before 6.11 cannot attach a PASID to an identity domain, which breaks GPU
 # ATS/SVA under iommu.passthrough=1. Sorts last so this value is the one that applies.
 GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX iommu.passthrough=0"
 EOF
+)"
 
 # Returns 0 when the configured service/accelerator opts in.
 iommu_enabled() {
@@ -129,6 +130,17 @@ regenerate_grub() {
     fi
 }
 
+# Drop a drop-in this package previously wrote. Without this, `false` cannot restore
+# passthrough and a kernel upgraded past the threshold keeps the workaround pinned on,
+# because the stale file still contributes iommu.passthrough=0 at the next boot.
+remove_dropin() {
+    [[ -f "${IOMMU_GRUB_DROPIN}" ]] || return 0
+
+    rm -f "${IOMMU_GRUB_DROPIN}"
+    regenerate_grub
+    echo "Removed ${IOMMU_GRUB_DROPIN}; a reboot is required to restore IOMMU passthrough"
+}
+
 main() {
     local policy
     policy="$(iommu_policy)"
@@ -139,12 +151,14 @@ main() {
     fi
 
     if [[ "${policy}" == "never" ]]; then
-        echo "IOMMU passthrough workaround switched off via CONFIGURE_IOMMU_PASSTHROUGH; nothing to do"
+        echo "IOMMU passthrough workaround switched off via CONFIGURE_IOMMU_PASSTHROUGH"
+        remove_dropin
         return 0
     fi
 
     if [[ "${policy}" == "auto" ]] && ! kernel_predates_fix; then
-        echo "Kernel $(uname -r) is >= ${IOMMU_PASSTHROUGH_MIN_KERNEL}; nothing to do"
+        echo "Kernel $(uname -r) is >= ${IOMMU_PASSTHROUGH_MIN_KERNEL}; passthrough is fine here"
+        remove_dropin
         return 0
     fi
 

--- a/nvidia-tuned/skyhook_dir/configure_iommu_passthrough.sh
+++ b/nvidia-tuned/skyhook_dir/configure_iommu_passthrough.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Disables IOMMU passthrough on kernels that need it to run ACS + DMA-BUF.
+#
+# OCI ships iommu.passthrough=1, so devices sit behind an identity domain. arm-smmu-v3
+# before 6.11 cannot attach a PASID to an identity domain, so nvidia_uvm's ATS/SVA bind
+# fails with -E2BIG and no CUDA context can be created at all -- cudaMalloc reports the
+# GPUs as busy on an idle node. Setting iommu.passthrough=0 restores translating domains,
+# and with them CUDA, GPUDirect RDMA and the DMA-BUF path the ACS correction sets up.
+#
+# Upstream: 6.10 made CD tables allocate-on-demand, 6.11 added S1DSS_BYPASS (PASID on an
+# identity STE). 6.11 is the threshold.
+#
+# Gated on ${SKYHOOK_DIR}/profiles/service/${service}/iommu-passthrough-${accelerator}.enabled,
+# so pairs without the marker are a no-op. CONFIGURE_IOMMU_PASSTHROUGH picks the policy:
+# auto (default, apply below IOMMU_PASSTHROUGH_MIN_KERNEL), true (always), false (never).
+# auto reads uname and vendor kernels backport, so it can guess wrong either way; the
+# explicit values are the escape hatch.
+#
+# Lands on the kernel command line, so it needs `interrupt: {type: reboot}`.
+
+set -euo pipefail
+
+CONFIGMAP_DIR="${SKYHOOK_DIR}/configmaps"
+PROFILES_DIR="${SKYHOOK_DIR}/profiles"
+
+# Overridable so tests can point at a stub.
+IOMMU_GRUB_DROPIN="${IOMMU_GRUB_DROPIN:-/etc/default/grub.d/99-iommu-passthrough.cfg}"
+# First kernel with arm-smmu-v3 S1DSS_BYPASS. Overridable so tests can pin the
+# threshold; not an operator knob -- use CONFIGURE_IOMMU_PASSTHROUGH instead.
+IOMMU_PASSTHROUGH_MIN_KERNEL="${IOMMU_PASSTHROUGH_MIN_KERNEL:-6.11}"
+
+# 99- sorts after every numbered producer, so this assignment is evaluated last.
+# iommu.passthrough is an early_param and do_early_param() runs the handler on each
+# occurrence in order, so the last value wins. Appending rather than rewriting keeps this
+# correct whether or not the platform ships its own drop-in.
+read -r -d '' DROPIN_CONTENT <<'EOF' || true
+# Managed by the nvidia-tuned Skyhook package. Do not edit.
+#
+# arm-smmu-v3 before 6.11 cannot attach a PASID to an identity domain, which breaks GPU
+# ATS/SVA under iommu.passthrough=1. Sorts last so this value is the one that applies.
+GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX iommu.passthrough=0"
+EOF
+
+# Returns 0 when the configured service/accelerator opts in.
+iommu_enabled() {
+    local service accelerator
+
+    [[ -f "${CONFIGMAP_DIR}/service" ]] || return 1
+    service="$(xargs < "${CONFIGMAP_DIR}/service")"
+    [[ -n "${service}" ]] || return 1
+
+    [[ -f "${CONFIGMAP_DIR}/accelerator" ]] || return 1
+    accelerator="$(xargs < "${CONFIGMAP_DIR}/accelerator")"
+    [[ -n "${accelerator}" ]] || return 1
+
+    [[ -f "${PROFILES_DIR}/service/${service}/iommu-passthrough-${accelerator}.enabled" ]]
+}
+
+# Echoes always | never | auto. Unrecognised values are auto.
+iommu_policy() {
+    local setting
+    setting="$(printf '%s' "${CONFIGURE_IOMMU_PASSTHROUGH:-auto}" | tr '[:upper:]' '[:lower:]')"
+    case "${setting}" in
+        false | 0 | no | off) echo "never" ;;
+        true | 1 | yes | on) echo "always" ;;
+        *) echo "auto" ;;
+    esac
+}
+
+# Returns 0 when uname -r is older than IOMMU_PASSTHROUGH_MIN_KERNEL (major.minor only).
+# An unparseable version is treated as new enough: applying a boot-affecting change to an
+# unknown platform is the worse failure.
+kernel_predates_fix() {
+    local rel major minor want_major want_minor
+
+    rel="$(uname -r)"
+    major="${rel%%.*}"
+    minor="${rel#*.}"
+    minor="${minor%%.*}"
+
+    want_major="${IOMMU_PASSTHROUGH_MIN_KERNEL%%.*}"
+    want_minor="${IOMMU_PASSTHROUGH_MIN_KERNEL#*.}"
+    want_minor="${want_minor%%.*}"
+
+    if ! [[ "${major}" =~ ^[0-9]+$ && "${minor}" =~ ^[0-9]+$ ]]; then
+        echo "WARNING: cannot parse kernel version '${rel}'; treating as new enough"
+        return 1
+    fi
+
+    if (( major < want_major )); then
+        return 0
+    fi
+    if (( major == want_major && minor < want_minor )); then
+        return 0
+    fi
+    return 1
+}
+
+# Mirrors the fallback chain in kdump's update_grub_config().
+regenerate_grub() {
+    if command -v update-grub >/dev/null 2>&1; then
+        update-grub
+    elif command -v grub2-mkconfig >/dev/null 2>&1; then
+        if [[ -d /boot/grub2 ]]; then
+            grub2-mkconfig -o /boot/grub2/grub.cfg
+        else
+            grub2-mkconfig -o /boot/efi/EFI/redhat/grub.cfg
+        fi
+    else
+        echo "ERROR: neither update-grub nor grub2-mkconfig is available"
+        exit 1
+    fi
+}
+
+main() {
+    local policy
+    policy="$(iommu_policy)"
+
+    if ! iommu_enabled; then
+        echo "IOMMU passthrough workaround not enabled for this service/accelerator; nothing to do"
+        return 0
+    fi
+
+    if [[ "${policy}" == "never" ]]; then
+        echo "IOMMU passthrough workaround switched off via CONFIGURE_IOMMU_PASSTHROUGH; nothing to do"
+        return 0
+    fi
+
+    if [[ "${policy}" == "auto" ]] && ! kernel_predates_fix; then
+        echo "Kernel $(uname -r) is >= ${IOMMU_PASSTHROUGH_MIN_KERNEL}; nothing to do"
+        return 0
+    fi
+
+    # Compare content rather than just existence, so a drop-in left by an older version of
+    # this package is corrected instead of silently kept.
+    if [[ -f "${IOMMU_GRUB_DROPIN}" ]] \
+        && [[ "$(cat "${IOMMU_GRUB_DROPIN}")" == "${DROPIN_CONTENT}" ]]; then
+        echo "IOMMU passthrough drop-in already current at ${IOMMU_GRUB_DROPIN}; nothing to do"
+        return 0
+    fi
+
+    echo "Kernel $(uname -r) predates ${IOMMU_PASSTHROUGH_MIN_KERNEL}; disabling IOMMU passthrough"
+    mkdir -p "$(dirname "${IOMMU_GRUB_DROPIN}")"
+    printf '%s\n' "${DROPIN_CONTENT}" > "${IOMMU_GRUB_DROPIN}"
+    regenerate_grub
+    echo "Wrote ${IOMMU_GRUB_DROPIN}; a reboot is required for it to take effect"
+}
+
+main "$@"

--- a/nvidia-tuned/skyhook_dir/configure_iommu_passthrough.sh
+++ b/nvidia-tuned/skyhook_dir/configure_iommu_passthrough.sh
@@ -135,9 +135,10 @@ regenerate_grub() {
     fi
 }
 
-# Drop a drop-in this package previously wrote. Without this, `false` cannot restore
-# passthrough and a kernel upgraded past the threshold keeps the workaround pinned on,
-# because the stale file still contributes iommu.passthrough=0 at the next boot.
+# Drop a drop-in this package previously wrote. Called from every path where the step
+# stands down: the profile gate no longer matching, `false`, and a kernel upgraded past
+# the threshold. Without it the stale file keeps contributing iommu.passthrough=0 at the
+# next boot while the step reports a no-op.
 remove_dropin() {
     [[ -f "${IOMMU_GRUB_DROPIN}" ]] || return 0
 
@@ -151,7 +152,8 @@ main() {
     policy="$(iommu_policy)"
 
     if ! iommu_enabled; then
-        echo "IOMMU passthrough workaround not enabled for this service/accelerator; nothing to do"
+        echo "IOMMU passthrough workaround not enabled for this service/accelerator"
+        remove_dropin
         return 0
     fi
 

--- a/nvidia-tuned/skyhook_dir/configure_iommu_passthrough.sh
+++ b/nvidia-tuned/skyhook_dir/configure_iommu_passthrough.sh
@@ -188,15 +188,31 @@ main() {
     fi
 
     echo "Kernel $(uname -r) predates ${IOMMU_PASSTHROUGH_MIN_KERNEL}; disabling IOMMU passthrough"
+    # Capture whatever is there now, so a failed regeneration can put the host back as it
+    # was rather than approximating it. Replacing a stale drop-in and then deleting it on
+    # failure would strand the generated config carrying its value with no source file.
+    local backup=""
+    if [[ -f "${IOMMU_GRUB_DROPIN}" ]]; then
+        backup="$(mktemp)"
+        cp "${IOMMU_GRUB_DROPIN}" "${backup}"
+    fi
+
     mkdir -p "$(dirname "${IOMMU_GRUB_DROPIN}")"
     printf '%s\n' "${DROPIN_CONTENT}" > "${IOMMU_GRUB_DROPIN}"
 
-    # Drop the file again if the bootloader config could not be rebuilt, so the drop-in
-    # never outlives a failed regeneration and mislead the config check into passing.
     if ! regenerate_grub; then
-        rm -f "${IOMMU_GRUB_DROPIN}"
-        echo "ERROR: could not regenerate the bootloader config; removed ${IOMMU_GRUB_DROPIN}"
+        if [[ -n "${backup}" ]]; then
+            mv "${backup}" "${IOMMU_GRUB_DROPIN}"
+            echo "ERROR: could not regenerate the bootloader config; restored the previous ${IOMMU_GRUB_DROPIN}"
+        else
+            rm -f "${IOMMU_GRUB_DROPIN}"
+            echo "ERROR: could not regenerate the bootloader config; removed ${IOMMU_GRUB_DROPIN}"
+        fi
         exit 1
+    fi
+
+    if [[ -n "${backup}" ]]; then
+        rm -f "${backup}"
     fi
 
     echo "Wrote ${IOMMU_GRUB_DROPIN}; a reboot is required for it to take effect"

--- a/nvidia-tuned/skyhook_dir/configure_iommu_passthrough.sh
+++ b/nvidia-tuned/skyhook_dir/configure_iommu_passthrough.sh
@@ -131,7 +131,7 @@ regenerate_grub() {
         fi
     else
         echo "ERROR: neither update-grub nor grub2-mkconfig is available"
-        exit 1
+        return 1
     fi
 }
 
@@ -142,8 +142,18 @@ regenerate_grub() {
 remove_dropin() {
     [[ -f "${IOMMU_GRUB_DROPIN}" ]] || return 0
 
+    local backup
+    backup="$(mktemp)"
+    cp "${IOMMU_GRUB_DROPIN}" "${backup}"
     rm -f "${IOMMU_GRUB_DROPIN}"
-    regenerate_grub
+
+    if ! regenerate_grub; then
+        mv "${backup}" "${IOMMU_GRUB_DROPIN}"
+        echo "ERROR: could not regenerate the bootloader config; restored ${IOMMU_GRUB_DROPIN}"
+        exit 1
+    fi
+
+    rm -f "${backup}"
     echo "Removed ${IOMMU_GRUB_DROPIN}; a reboot is required to restore IOMMU passthrough"
 }
 
@@ -180,7 +190,15 @@ main() {
     echo "Kernel $(uname -r) predates ${IOMMU_PASSTHROUGH_MIN_KERNEL}; disabling IOMMU passthrough"
     mkdir -p "$(dirname "${IOMMU_GRUB_DROPIN}")"
     printf '%s\n' "${DROPIN_CONTENT}" > "${IOMMU_GRUB_DROPIN}"
-    regenerate_grub
+
+    # Drop the file again if the bootloader config could not be rebuilt, so the drop-in
+    # never outlives a failed regeneration and mislead the config check into passing.
+    if ! regenerate_grub; then
+        rm -f "${IOMMU_GRUB_DROPIN}"
+        echo "ERROR: could not regenerate the bootloader config; removed ${IOMMU_GRUB_DROPIN}"
+        exit 1
+    fi
+
     echo "Wrote ${IOMMU_GRUB_DROPIN}; a reboot is required for it to take effect"
 }
 

--- a/nvidia-tuned/skyhook_dir/configure_iommu_passthrough_check.sh
+++ b/nvidia-tuned/skyhook_dir/configure_iommu_passthrough_check.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Verifies configure_iommu_passthrough.sh left a drop-in that will disable IOMMU
+# passthrough on the next boot.
+#
+# Runs before the reboot, so live state still shows passthrough; passing only means the
+# drop-in is in place. post_interrupt_iommu_passthrough_check.sh asserts it took effect.
+# A non-zero exit is the signal, so no `set -e`.
+
+set -uo pipefail
+
+CONFIGMAP_DIR="${SKYHOOK_DIR}/configmaps"
+PROFILES_DIR="${SKYHOOK_DIR}/profiles"
+
+IOMMU_GRUB_DROPIN="${IOMMU_GRUB_DROPIN:-/etc/default/grub.d/99-iommu-passthrough.cfg}"
+# First kernel with arm-smmu-v3 S1DSS_BYPASS. Overridable so tests can pin the
+# threshold; not an operator knob -- use CONFIGURE_IOMMU_PASSTHROUGH instead.
+IOMMU_PASSTHROUGH_MIN_KERNEL="${IOMMU_PASSTHROUGH_MIN_KERNEL:-6.11}"
+
+# Mirrors iommu_enabled() in configure_iommu_passthrough.sh.
+iommu_enabled() {
+    local service accelerator
+
+    [[ -f "${CONFIGMAP_DIR}/service" ]] || return 1
+    service="$(xargs < "${CONFIGMAP_DIR}/service")"
+    [[ -n "${service}" ]] || return 1
+
+    [[ -f "${CONFIGMAP_DIR}/accelerator" ]] || return 1
+    accelerator="$(xargs < "${CONFIGMAP_DIR}/accelerator")"
+    [[ -n "${accelerator}" ]] || return 1
+
+    [[ -f "${PROFILES_DIR}/service/${service}/iommu-passthrough-${accelerator}.enabled" ]]
+}
+
+# Mirrors iommu_policy() in configure_iommu_passthrough.sh.
+iommu_policy() {
+    local setting
+    setting="$(printf '%s' "${CONFIGURE_IOMMU_PASSTHROUGH:-auto}" | tr '[:upper:]' '[:lower:]')"
+    case "${setting}" in
+        false | 0 | no | off) echo "never" ;;
+        true | 1 | yes | on) echo "always" ;;
+        *) echo "auto" ;;
+    esac
+}
+
+# Mirrors kernel_predates_fix() in configure_iommu_passthrough.sh.
+kernel_predates_fix() {
+    local rel major minor want_major want_minor
+
+    rel="$(uname -r)"
+    major="${rel%%.*}"
+    minor="${rel#*.}"
+    minor="${minor%%.*}"
+
+    want_major="${IOMMU_PASSTHROUGH_MIN_KERNEL%%.*}"
+    want_minor="${IOMMU_PASSTHROUGH_MIN_KERNEL#*.}"
+    want_minor="${want_minor%%.*}"
+
+    if ! [[ "${major}" =~ ^[0-9]+$ && "${minor}" =~ ^[0-9]+$ ]]; then
+        return 1
+    fi
+
+    if (( major < want_major )); then
+        return 0
+    fi
+    if (( major == want_major && minor < want_minor )); then
+        return 0
+    fi
+    return 1
+}
+
+main() {
+    local policy
+    policy="$(iommu_policy)"
+
+    if ! iommu_enabled; then
+        echo "IOMMU passthrough workaround not enabled for this service/accelerator; nothing to verify"
+        return 0
+    fi
+
+    if [[ "${policy}" == "never" ]]; then
+        echo "IOMMU passthrough workaround switched off via CONFIGURE_IOMMU_PASSTHROUGH; nothing to verify"
+        return 0
+    fi
+
+    if [[ "${policy}" == "auto" ]] && ! kernel_predates_fix; then
+        echo "Kernel $(uname -r) is >= ${IOMMU_PASSTHROUGH_MIN_KERNEL}; no drop-in expected"
+        return 0
+    fi
+
+    if [[ ! -f "${IOMMU_GRUB_DROPIN}" ]]; then
+        echo "ERROR: IOMMU passthrough workaround was requested but no bootloader drop-in exists at ${IOMMU_GRUB_DROPIN}"
+        exit 1
+    fi
+
+    # Match an active assignment, not a commented one, so a drop-in that contributes
+    # nothing fails here rather than after the reboot. Comment-strip first; see the
+    # equivalent note in configure_pcie_acs_check.sh for why one regex is not enough.
+    if ! awk '{ sub(/#.*/, ""); if ($0 ~ /iommu\.passthrough=0/) found = 1 } END { exit !found }' \
+        "${IOMMU_GRUB_DROPIN}"; then
+        echo "ERROR: ${IOMMU_GRUB_DROPIN} does not contain an active iommu.passthrough=0 setting"
+        exit 1
+    fi
+
+    echo "Verified IOMMU passthrough drop-in at ${IOMMU_GRUB_DROPIN}; pending reboot"
+}
+
+main "$@"

--- a/nvidia-tuned/skyhook_dir/post_interrupt_iommu_passthrough_check.sh
+++ b/nvidia-tuned/skyhook_dir/post_interrupt_iommu_passthrough_check.sh
@@ -135,6 +135,14 @@ main() {
 
     effective="$(effective_passthrough)"
 
+    # Unset is a failure, not a pass. The drop-in sets the token explicitly, so its absence
+    # means nothing this package wrote reached the booted kernel. Accepting it because the
+    # kernel happened to default to translated would hide a drop-in that never applied.
+    if [[ -z "${effective}" ]]; then
+        fail_not_applied \
+            "The booted kernel command line (${PROC_CMDLINE}) carries no iommu.passthrough argument, so the drop-in never reached the kernel. Check for a later-sorting file in /etc/default/grub.d/ that overwrites GRUB_CMDLINE_LINUX, and check which entry GRUB_DEFAULT boots."
+    fi
+
     if [[ "${effective}" == "1" ]]; then
         fail_not_applied \
             "The booted kernel command line still resolves iommu.passthrough to 1. The last occurrence wins, so a file sorting after 99-iommu-passthrough.cfg in /etc/default/grub.d/ is overriding it, or the drop-in never reached grub.cfg. Check which entry GRUB_DEFAULT boots."
@@ -145,7 +153,7 @@ main() {
             "No IOMMU group under ${IOMMU_GROUPS_DIR} is using a translating (DMA or DMA-FQ) domain, so the SMMU is still in bypass. 'dmesg | grep \"Default domain type\"' shows what the kernel resolved at boot."
     fi
 
-    echo "Verified IOMMU translation is active after reboot (iommu.passthrough=${effective:-unset})"
+    echo "Verified IOMMU translation is active after reboot (iommu.passthrough=${effective})"
 }
 
 # The only place an operator will look, so name the cause, the cost and the switch.

--- a/nvidia-tuned/skyhook_dir/post_interrupt_iommu_passthrough_check.sh
+++ b/nvidia-tuned/skyhook_dir/post_interrupt_iommu_passthrough_check.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Verifies IOMMU translation is live after the reboot interrupt.
+#
+# GATES: if the workaround was requested and did not take effect, the node cannot run
+# CUDA at all, so this fails rather than letting it come up broken.
+# CONFIGURE_IOMMU_PASSTHROUGH=false skips both the change and this check.
+
+set -uo pipefail
+
+CONFIGMAP_DIR="${SKYHOOK_DIR}/configmaps"
+PROFILES_DIR="${SKYHOOK_DIR}/profiles"
+
+PROC_CMDLINE="${PROC_CMDLINE:-/proc/cmdline}"
+IOMMU_GROUPS_DIR="${IOMMU_GROUPS_DIR:-/sys/kernel/iommu_groups}"
+# First kernel with arm-smmu-v3 S1DSS_BYPASS. Overridable so tests can pin the
+# threshold; not an operator knob -- use CONFIGURE_IOMMU_PASSTHROUGH instead.
+IOMMU_PASSTHROUGH_MIN_KERNEL="${IOMMU_PASSTHROUGH_MIN_KERNEL:-6.11}"
+
+# Mirrors iommu_enabled() in configure_iommu_passthrough.sh.
+iommu_enabled() {
+    local service accelerator
+
+    [[ -f "${CONFIGMAP_DIR}/service" ]] || return 1
+    service="$(xargs < "${CONFIGMAP_DIR}/service")"
+    [[ -n "${service}" ]] || return 1
+
+    [[ -f "${CONFIGMAP_DIR}/accelerator" ]] || return 1
+    accelerator="$(xargs < "${CONFIGMAP_DIR}/accelerator")"
+    [[ -n "${accelerator}" ]] || return 1
+
+    [[ -f "${PROFILES_DIR}/service/${service}/iommu-passthrough-${accelerator}.enabled" ]]
+}
+
+# Mirrors iommu_policy() in configure_iommu_passthrough.sh.
+iommu_policy() {
+    local setting
+    setting="$(printf '%s' "${CONFIGURE_IOMMU_PASSTHROUGH:-auto}" | tr '[:upper:]' '[:lower:]')"
+    case "${setting}" in
+        false | 0 | no | off) echo "never" ;;
+        true | 1 | yes | on) echo "always" ;;
+        *) echo "auto" ;;
+    esac
+}
+
+# Mirrors kernel_predates_fix() in configure_iommu_passthrough.sh.
+kernel_predates_fix() {
+    local rel major minor want_major want_minor
+
+    rel="$(uname -r)"
+    major="${rel%%.*}"
+    minor="${rel#*.}"
+    minor="${minor%%.*}"
+
+    want_major="${IOMMU_PASSTHROUGH_MIN_KERNEL%%.*}"
+    want_minor="${IOMMU_PASSTHROUGH_MIN_KERNEL#*.}"
+    want_minor="${want_minor%%.*}"
+
+    if ! [[ "${major}" =~ ^[0-9]+$ && "${minor}" =~ ^[0-9]+$ ]]; then
+        return 1
+    fi
+
+    if (( major < want_major )); then
+        return 0
+    fi
+    if (( major == want_major && minor < want_minor )); then
+        return 0
+    fi
+    return 1
+}
+
+# The effective iommu.passthrough value, or empty if unset.
+#
+# The token legitimately appears twice: the platform sets 1 and our drop-in appends 0.
+# The last occurrence is the one the kernel acted on, so grepping for =0 anywhere would
+# pass even when something later set it back to 1 -- the failure this check exists for.
+effective_passthrough() {
+    tr ' ' '\n' < "${PROC_CMDLINE}" \
+        | grep '^iommu\.passthrough=' \
+        | tail -1 \
+        | cut -d= -f2
+}
+
+# True when at least one IOMMU group uses a translating domain.
+#
+# sysfs rather than the dmesg "Default domain type:" line, which can wrap out of the ring
+# buffer. Only "at least one" is required: a driver may legitimately request an identity
+# domain for its own device.
+translation_active() {
+    local t
+    for t in "${IOMMU_GROUPS_DIR}"/*/type; do
+        [[ -r "${t}" ]] || continue
+        case "$(cat "${t}" 2>/dev/null)" in
+            DMA | DMA-FQ) return 0 ;;
+        esac
+    done
+    return 1
+}
+
+main() {
+    local policy effective
+
+    policy="$(iommu_policy)"
+
+    if ! iommu_enabled; then
+        echo "IOMMU passthrough workaround not enabled for this service/accelerator; nothing to verify"
+        return 0
+    fi
+
+    if [[ "${policy}" == "never" ]]; then
+        echo "IOMMU passthrough workaround switched off via CONFIGURE_IOMMU_PASSTHROUGH; nothing to verify"
+        return 0
+    fi
+
+    if [[ "${policy}" == "auto" ]] && ! kernel_predates_fix; then
+        echo "Kernel $(uname -r) is >= ${IOMMU_PASSTHROUGH_MIN_KERNEL}; passthrough is fine on this kernel, nothing to verify"
+        return 0
+    fi
+
+    effective="$(effective_passthrough)"
+
+    if [[ "${effective}" == "1" ]]; then
+        fail_not_applied \
+            "The booted kernel command line still resolves iommu.passthrough to 1. The last occurrence wins, so a file sorting after 99-iommu-passthrough.cfg in /etc/default/grub.d/ is overriding it, or the drop-in never reached grub.cfg. Check which entry GRUB_DEFAULT boots."
+    fi
+
+    if ! translation_active; then
+        fail_not_applied \
+            "No IOMMU group under ${IOMMU_GROUPS_DIR} is using a translating (DMA or DMA-FQ) domain, so the SMMU is still in bypass. 'dmesg | grep \"Default domain type\"' shows what the kernel resolved at boot."
+    fi
+
+    echo "Verified IOMMU translation is active after reboot (iommu.passthrough=${effective:-unset})"
+}
+
+# The only place an operator will look, so name the cause, the cost and the switch.
+fail_not_applied() {
+    cat <<EOF
+ERROR: The IOMMU passthrough workaround was requested but did not take effect on this node.
+
+  ${1}
+
+  Impact: on a kernel older than ${IOMMU_PASSTHROUGH_MIN_KERNEL}, arm-smmu-v3 cannot attach a PASID to an
+  identity domain, so nvidia_uvm's ATS/SVA bind fails with -E2BIG and NO CUDA context
+  can be created. cudaMalloc reports "CUDA-capable device(s) is/are busy or unavailable"
+  even with no processes on the GPUs. DCGM, the GPU operator validators and every GPU
+  workload fail together. Look for arm_smmu_write_ctx_desc in dmesg to confirm.
+
+  If this node should keep IOMMU passthrough (for example its kernel carries a backported
+  fix that the version check cannot see), set CONFIGURE_IOMMU_PASSTHROUGH=false in the
+  package env on the custom resource. That skips the change and this check.
+EOF
+    exit 1
+}
+
+main "$@"

--- a/nvidia-tuned/skyhook_dir/post_interrupt_iommu_passthrough_check.sh
+++ b/nvidia-tuned/skyhook_dir/post_interrupt_iommu_passthrough_check.sh
@@ -143,9 +143,12 @@ main() {
             "The booted kernel command line (${PROC_CMDLINE}) carries no iommu.passthrough argument, so the drop-in never reached the kernel. Check for a later-sorting file in /etc/default/grub.d/ that overwrites GRUB_CMDLINE_LINUX, and check which entry GRUB_DEFAULT boots."
     fi
 
-    if [[ "${effective}" == "1" ]]; then
+    # Allowlist rather than rejecting "1". The kernel parses this with kstrtobool(), so
+    # y/on/true/t all enable passthrough, and only the exact value the drop-in writes
+    # proves the drop-in is what decided it.
+    if [[ "${effective}" != "0" ]]; then
         fail_not_applied \
-            "The booted kernel command line still resolves iommu.passthrough to 1. The last occurrence wins, so a file sorting after 99-iommu-passthrough.cfg in /etc/default/grub.d/ is overriding it, or the drop-in never reached grub.cfg. Check which entry GRUB_DEFAULT boots."
+            "The booted kernel command line resolves iommu.passthrough to '${effective}' rather than 0. The last occurrence wins, so a file sorting after 99-iommu-passthrough.cfg in /etc/default/grub.d/ is overriding it, or the drop-in never reached grub.cfg. Check which entry GRUB_DEFAULT boots."
     fi
 
     if ! translation_active; then

--- a/nvidia-tuned/skyhook_dir/uninstall_iommu_passthrough.sh
+++ b/nvidia-tuned/skyhook_dir/uninstall_iommu_passthrough.sh
@@ -47,7 +47,7 @@ regenerate_grub() {
         fi
     else
         echo "ERROR: neither update-grub nor grub2-mkconfig is available"
-        exit 1
+        return 1
     fi
 }
 
@@ -57,8 +57,21 @@ main() {
         return 0
     fi
 
+    # Back the drop-in up before removing it. If GRUB regeneration fails the generated
+    # config still carries iommu.passthrough=0, and leaving the source file deleted would
+    # make the next uninstall report success against a node that still boots with it.
+    local backup
+    backup="$(mktemp)"
+    cp "${IOMMU_GRUB_DROPIN}" "${backup}"
     rm -f "${IOMMU_GRUB_DROPIN}"
-    regenerate_grub
+
+    if ! regenerate_grub; then
+        mv "${backup}" "${IOMMU_GRUB_DROPIN}"
+        echo "ERROR: could not regenerate the bootloader config; restored ${IOMMU_GRUB_DROPIN}"
+        return 1
+    fi
+
+    rm -f "${backup}"
     echo "Removed ${IOMMU_GRUB_DROPIN}; a reboot is required to restore IOMMU passthrough"
 }
 

--- a/nvidia-tuned/skyhook_dir/uninstall_iommu_passthrough.sh
+++ b/nvidia-tuned/skyhook_dir/uninstall_iommu_passthrough.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Removes the IOMMU passthrough drop-in written by configure_iommu_passthrough.sh.
+#
+# Runs unconditionally rather than self-gating on the service/accelerator assets:
+# uninstall must also clean up after a custom resource whose configmaps have since
+# changed, so it keys on what is on the host. Removing a drop-in that was never written
+# is a no-op.
+#
+# Unlike the PCIe ACS drop-in, which corrects a hardware misconfiguration and is
+# deliberately left in place, this one is purely a workaround for kernels that cannot
+# attach a PASID to an identity domain. Removing it restores the platform's own
+# passthrough setting, which is the correct as-if-never-installed state. Leaving it
+# would keep forcing iommu.passthrough=0 on every future boot with no package owning it.
+#
+# Takes effect on the next boot, like the change it reverts.
+
+set -euo pipefail
+
+IOMMU_GRUB_DROPIN="${IOMMU_GRUB_DROPIN:-/etc/default/grub.d/99-iommu-passthrough.cfg}"
+
+# Mirrors the fallback chain in kdump's update_grub_config().
+regenerate_grub() {
+    if command -v update-grub >/dev/null 2>&1; then
+        update-grub
+    elif command -v grub2-mkconfig >/dev/null 2>&1; then
+        if [[ -d /boot/grub2 ]]; then
+            grub2-mkconfig -o /boot/grub2/grub.cfg
+        else
+            grub2-mkconfig -o /boot/efi/EFI/redhat/grub.cfg
+        fi
+    else
+        echo "ERROR: neither update-grub nor grub2-mkconfig is available"
+        exit 1
+    fi
+}
+
+main() {
+    if [[ ! -f "${IOMMU_GRUB_DROPIN}" ]]; then
+        echo "${IOMMU_GRUB_DROPIN} is not present; nothing to remove"
+        return 0
+    fi
+
+    rm -f "${IOMMU_GRUB_DROPIN}"
+    regenerate_grub
+    echo "Removed ${IOMMU_GRUB_DROPIN}; a reboot is required to restore IOMMU passthrough"
+}
+
+main "$@"

--- a/nvidia-tuned/skyhook_dir/uninstall_iommu_passthrough_check.sh
+++ b/nvidia-tuned/skyhook_dir/uninstall_iommu_passthrough_check.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Verifies uninstall_iommu_passthrough.sh removed the IOMMU passthrough drop-in.
+#
+# A non-zero exit is the signal here, so this script does not use `set -e`; expected
+# failures are handled explicitly.
+#
+# Asserts the drop-in is gone rather than that passthrough is live: the change only takes
+# effect at the next boot, so live state still shows whatever the running kernel booted
+# with.
+
+set -uo pipefail
+
+IOMMU_GRUB_DROPIN="${IOMMU_GRUB_DROPIN:-/etc/default/grub.d/99-iommu-passthrough.cfg}"
+
+main() {
+    if [[ -e "${IOMMU_GRUB_DROPIN}" ]]; then
+        echo "ERROR: ${IOMMU_GRUB_DROPIN} still present"
+        exit 1
+    fi
+
+    echo "Verified the IOMMU passthrough drop-in is removed"
+}
+
+main "$@"

--- a/nvidia-tuned/skyhook_dir/uninstall_spcx_cc_check.sh
+++ b/nvidia-tuned/skyhook_dir/uninstall_spcx_cc_check.sh
@@ -43,8 +43,15 @@ main() {
         exit 1
     fi
 
+    # Ignore units whose LOAD column is not-found. Removing the template unit file is
+    # exactly what makes an instance not-found, and systemd keeps the stub listed under
+    # --all until it is garbage collected, so a successful uninstall leaves these behind.
+    # Counting them made the check unpassable: the device units udev created still
+    # reference the instances, so the stubs survive daemon-reload, and reset-failed does
+    # not clear them because they are inactive/dead rather than failed. Only a unit that
+    # is still loaded means the uninstall did not finish.
     local remaining
-    remaining="$(systemctl list-units --all --plain --no-legend 'doca-spcx-cc@*.service' 2>/dev/null | awk '{print $1}')"
+    remaining="$(systemctl list-units --all --plain --no-legend 'doca-spcx-cc@*.service' 2>/dev/null | awk '$2 != "not-found" {print $1}')"
     if [[ -n "${remaining}" ]]; then
         echo "ERROR: doca-spcx-cc@ unit(s) still known to systemd:"
         local unit

--- a/tests/integration/nvidia_tuned/fakes/systemctl
+++ b/tests/integration/nvidia_tuned/fakes/systemctl
@@ -100,18 +100,26 @@ case "${verb}" in
         # `unit` holds the glob the caller passed, e.g. 'doca-spcx-cc@*.service'.
         # Emit one unit name per line; callers take field 1.
         seen=""
-        for marker in "${STATE_DIR}"/enabled.* "${STATE_DIR}"/active.*; do
+        for marker in "${STATE_DIR}"/enabled.* "${STATE_DIR}"/active.* "${STATE_DIR}"/stub.*; do
             [[ -e "${marker}" ]] || continue
             name="${marker##*/}"
+            # A stub.<unit> marker models what systemd lists after the unit file is
+            # removed: the instance is still enumerated under --all, but LOAD reads
+            # not-found. That residue is what a successful uninstall leaves behind.
+            case "${name}" in
+                stub.*) load="not-found inactive dead" ;;
+                *) load="loaded active running" ;;
+            esac
             name="${name#enabled.}"
             name="${name#active.}"
+            name="${name#stub.}"
             case " ${seen} " in *" ${name} "*) continue ;; esac
             seen="${seen} ${name}"
             # Glob matching on the right-hand side is the point: callers pass a
             # pattern such as 'doca-spcx-cc@*.service'.
             # shellcheck disable=SC2053
             if [[ -z "${unit}" || "${name}" == ${unit} ]]; then
-                echo "${name} loaded active running fake unit"
+                echo "${name} ${load} fake unit"
             fi
         done
         ;;

--- a/tests/integration/nvidia_tuned/fakes/uname
+++ b/tests/integration/nvidia_tuned/fakes/uname
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Test double for uname. Reports FAKE_UNAME_R for `uname -r` so tests can pin the kernel
+# version the IOMMU passthrough policy sees. Every other invocation, and any invocation
+# with FAKE_UNAME_R unset, defers to the real binary.
+
+set -euo pipefail
+
+if [[ "${1:-}" == "-r" && -n "${FAKE_UNAME_R:-}" ]]; then
+    echo "${FAKE_UNAME_R}"
+    exit 0
+fi
+
+exec /usr/bin/uname "$@"

--- a/tests/integration/nvidia_tuned/fakes/update-grub
+++ b/tests/integration/nvidia_tuned/fakes/update-grub
@@ -24,5 +24,13 @@ set -euo pipefail
 STATE_DIR="${FAKE_GRUB_STATE:-/tmp/fake-grub}"
 mkdir -p "${STATE_DIR}"
 touch "${STATE_DIR}/update-grub-ran"
+
+# FAKE_GRUB_FAIL lets a test drive the failure path: a caller that removes or writes a
+# bootloader drop-in has to leave the host consistent when regeneration does not succeed.
+if [[ -n "${FAKE_GRUB_FAIL:-}" ]]; then
+    echo "error: cannot open /boot/grub/grub.cfg for writing" >&2
+    exit 1
+fi
+
 echo "Generating grub configuration file ..."
 exit 0

--- a/tests/integration/nvidia_tuned/test_host_setup.py
+++ b/tests/integration/nvidia_tuned/test_host_setup.py
@@ -1022,3 +1022,42 @@ def test_iommu_passthrough_post_interrupt_check_accepts_only_the_disabled_value(
 
     assert step(node, "post_interrupt_iommu_passthrough_check.sh", env) != 0
     assert said(node, f"resolves iommu.passthrough to '{value}' rather than 0"), output(node)
+
+
+def test_iommu_passthrough_uninstall_removes_the_dropin(node):
+    """Removing the package must not leave iommu.passthrough=0 forced on every boot."""
+    configure(node, **OCI_GB300)
+
+    assert step(node, "configure_iommu_passthrough.sh", on_kernel(OLD_KERNEL)) == 0
+    assert exists(node, IOMMU_DROPIN)
+
+    assert step(node, "uninstall_iommu_passthrough.sh") == 0, output(node)
+    assert said(node, "reboot is required to restore"), output(node)
+    assert not exists(node, IOMMU_DROPIN)
+
+    assert step(node, "uninstall_iommu_passthrough_check.sh") == 0, output(node)
+    assert said(node, "drop-in is removed"), output(node)
+
+
+def test_iommu_passthrough_uninstall_is_a_noop_when_never_configured(node):
+    """Uninstall keys on host state, so a node that never had the drop-in is fine."""
+    configure(node, **OCI_GB300)
+
+    assert step(node, "uninstall_iommu_passthrough.sh") == 0, output(node)
+    assert said(node, "is not present; nothing to remove"), output(node)
+    assert step(node, "uninstall_iommu_passthrough_check.sh") == 0, output(node)
+
+
+def test_iommu_passthrough_uninstall_runs_regardless_of_the_profile_gate(node):
+    """Uninstall must clean up after a custom resource whose configmaps have changed.
+
+    Gating on the bundled marker would strand the drop-in on a node that was re-profiled
+    before the package was removed.
+    """
+    configure(node, **OCI_GB300)
+    assert step(node, "configure_iommu_passthrough.sh", on_kernel(OLD_KERNEL)) == 0
+    assert exists(node, IOMMU_DROPIN)
+
+    configure(node, accelerator="h100", service="eks")
+    assert step(node, "uninstall_iommu_passthrough.sh") == 0, output(node)
+    assert not exists(node, IOMMU_DROPIN)

--- a/tests/integration/nvidia_tuned/test_host_setup.py
+++ b/tests/integration/nvidia_tuned/test_host_setup.py
@@ -728,7 +728,7 @@ def test_iommu_passthrough_is_a_noop_without_the_opt_in_marker(node, configmaps)
     old = on_kernel(OLD_KERNEL)
 
     assert step(node, "configure_iommu_passthrough.sh", old) == 0, output(node)
-    assert said(node, "nothing to do"), output(node)
+    assert said(node, "not enabled for this service/accelerator"), output(node)
     assert not exists(node, IOMMU_DROPIN)
 
     for check in ("configure_iommu_passthrough_check.sh",
@@ -985,3 +985,40 @@ def test_iommu_passthrough_post_interrupt_check_rejects_an_absent_value(node):
     # Still reaches the shared diagnostic rather than exiting early.
     assert said(node, "NO CUDA context"), output(node)
     assert said(node, "CONFIGURE_IOMMU_PASSTHROUGH=false"), output(node)
+
+
+def test_iommu_passthrough_removes_the_dropin_when_the_gate_stops_matching(node):
+    """A node re-profiled away from the opted-in pair must not keep the workaround.
+
+    The step owns this drop-in, so standing down has to take the file with it. Leaving it
+    would keep iommu.passthrough=0 on every later boot while both checks report a no-op.
+    """
+    configure(node, **OCI_GB300)
+    old = on_kernel(OLD_KERNEL)
+
+    assert step(node, "configure_iommu_passthrough.sh", old) == 0, output(node)
+    assert exists(node, IOMMU_DROPIN)
+
+    configure(node, accelerator="h100", service="eks")
+    assert step(node, "configure_iommu_passthrough.sh", old) == 0, output(node)
+    assert said(node, "reboot is required to restore"), output(node)
+    assert not exists(node, IOMMU_DROPIN)
+
+
+@pytest.mark.parametrize("value", ["1", "y", "on", "true", "2"])
+def test_iommu_passthrough_post_interrupt_check_accepts_only_the_disabled_value(
+    node, value
+):
+    """Anything but 0 means something other than this drop-in decided the value.
+
+    The kernel parses iommu.passthrough with kstrtobool(), so y/on/true all enable
+    passthrough. Rejecting just "1" would let those through with a translating group
+    present, reporting a node as fixed when the workaround never applied.
+    """
+    configure(node, **OCI_GB300)
+    env = on_kernel(
+        OLD_KERNEL, **booted(node, f"root=x iommu.passthrough={value}", "DMA-FQ")
+    )
+
+    assert step(node, "post_interrupt_iommu_passthrough_check.sh", env) != 0
+    assert said(node, f"resolves iommu.passthrough to '{value}' rather than 0"), output(node)

--- a/tests/integration/nvidia_tuned/test_host_setup.py
+++ b/tests/integration/nvidia_tuned/test_host_setup.py
@@ -1084,7 +1084,7 @@ def test_iommu_passthrough_restores_the_dropin_when_grub_regeneration_fails(node
 
 
 def test_iommu_passthrough_removes_the_dropin_when_grub_regeneration_fails_on_write(node):
-    """Symmetrically, a drop-in must not outlive a failed regeneration on the write path."""
+    """With nothing there before, a failed regeneration must leave nothing behind."""
     configure(node, **OCI_GB300)
 
     rc = step(node, "configure_iommu_passthrough.sh",
@@ -1092,3 +1092,24 @@ def test_iommu_passthrough_removes_the_dropin_when_grub_regeneration_fails_on_wr
     assert rc != 0, output(node)
     assert said(node, "could not regenerate"), output(node)
     assert not exists(node, IOMMU_DROPIN)
+
+
+def test_iommu_passthrough_restores_a_replaced_dropin_when_regeneration_fails(node):
+    """Replacing a stale drop-in must roll back to it, not to nothing.
+
+    The generated config still carries the stale value after a failed regeneration, so
+    deleting the file it came from would strand the host with the setting applied and no
+    source for it. Rollback has to restore what was there, not approximate it.
+    """
+    configure(node, **OCI_GB300)
+    assert sh(node, "mkdir -p /etc/default/grub.d") == 0
+    stale = "# stale drop-in from an older package version\niommu.passthrough=0"
+    assert sh(node, f"printf '%s\\n' {shell_quote(stale)} > {IOMMU_DROPIN}") == 0
+
+    rc = step(node, "configure_iommu_passthrough.sh",
+              on_kernel(OLD_KERNEL, FAKE_GRUB_FAIL="1"))
+    assert rc != 0, output(node)
+    assert said(node, "restored the previous"), output(node)
+    assert exists(node, IOMMU_DROPIN)
+    assert contains(node, IOMMU_DROPIN, "stale drop-in from an older package version")
+    assert not contains(node, IOMMU_DROPIN, "Managed by the nvidia-tuned Skyhook package")

--- a/tests/integration/nvidia_tuned/test_host_setup.py
+++ b/tests/integration/nvidia_tuned/test_host_setup.py
@@ -765,7 +765,7 @@ def test_iommu_passthrough_is_a_noop_on_a_fixed_kernel(node):
     new = on_kernel(NEW_KERNEL)
 
     assert step(node, "configure_iommu_passthrough.sh", new) == 0, output(node)
-    assert said(node, "nothing to do"), output(node)
+    assert said(node, "passthrough is fine here"), output(node)
     assert not exists(node, IOMMU_DROPIN)
 
     for check in ("configure_iommu_passthrough_check.sh",
@@ -930,3 +930,41 @@ def test_iommu_passthrough_failure_message_names_cause_impact_and_remedy(node):
     assert said(node, "arm_smmu_write_ctx_desc"), output(node)
     # Remedy: the documented opt-out.
     assert said(node, "CONFIGURE_IOMMU_PASSTHROUGH=false"), output(node)
+
+
+def test_iommu_passthrough_off_removes_a_previously_written_dropin(node):
+    """`false` has to restore passthrough, not just stop maintaining the drop-in.
+
+    A stale drop-in still contributes iommu.passthrough=0 at the next boot, so leaving it
+    in place would make the documented escape hatch unable to do the thing it documents.
+    """
+    configure(node, **OCI_GB300)
+
+    assert step(node, "configure_iommu_passthrough.sh", on_kernel(OLD_KERNEL)) == 0
+    assert exists(node, IOMMU_DROPIN)
+
+    off = on_kernel(OLD_KERNEL, CONFIGURE_IOMMU_PASSTHROUGH="false")
+    assert step(node, "configure_iommu_passthrough.sh", off) == 0, output(node)
+    assert said(node, "reboot is required to restore"), output(node)
+    assert not exists(node, IOMMU_DROPIN)
+
+
+def test_iommu_passthrough_removes_the_dropin_after_a_kernel_upgrade(node):
+    """A node upgraded past the threshold must not keep the workaround pinned on."""
+    configure(node, **OCI_GB300)
+
+    assert step(node, "configure_iommu_passthrough.sh", on_kernel(OLD_KERNEL)) == 0
+    assert exists(node, IOMMU_DROPIN)
+
+    assert step(node, "configure_iommu_passthrough.sh", on_kernel(NEW_KERNEL)) == 0
+    assert said(node, "reboot is required to restore"), output(node)
+    assert not exists(node, IOMMU_DROPIN)
+
+
+def test_iommu_passthrough_removal_is_idempotent(node):
+    """Standing down on a node that never had the drop-in must not claim it removed one."""
+    configure(node, **OCI_GB300)
+    off = on_kernel(OLD_KERNEL, CONFIGURE_IOMMU_PASSTHROUGH="false")
+
+    assert step(node, "configure_iommu_passthrough.sh", off) == 0, output(node)
+    assert not said(node, "Removed"), output(node)

--- a/tests/integration/nvidia_tuned/test_host_setup.py
+++ b/tests/integration/nvidia_tuned/test_host_setup.py
@@ -968,3 +968,20 @@ def test_iommu_passthrough_removal_is_idempotent(node):
 
     assert step(node, "configure_iommu_passthrough.sh", off) == 0, output(node)
     assert not said(node, "Removed"), output(node)
+
+
+def test_iommu_passthrough_post_interrupt_check_rejects_an_absent_value(node):
+    """An absent token means nothing this package wrote reached the booted kernel.
+
+    The drop-in sets iommu.passthrough explicitly, so its absence is a drop-in that never
+    applied. Accepting it because the kernel happened to default to a translating domain
+    would report a broken deployment as fixed.
+    """
+    configure(node, **OCI_GB300)
+    env = on_kernel(OLD_KERNEL, **booted(node, "root=x quiet", "DMA-FQ"))
+
+    assert step(node, "post_interrupt_iommu_passthrough_check.sh", env) != 0
+    assert said(node, "carries no iommu.passthrough argument"), output(node)
+    # Still reaches the shared diagnostic rather than exiting early.
+    assert said(node, "NO CUDA context"), output(node)
+    assert said(node, "CONFIGURE_IOMMU_PASSTHROUGH=false"), output(node)

--- a/tests/integration/nvidia_tuned/test_host_setup.py
+++ b/tests/integration/nvidia_tuned/test_host_setup.py
@@ -901,7 +901,7 @@ def test_iommu_passthrough_post_interrupt_check_reads_the_last_cmdline_value(nod
                              "identity", "identity"))
 
     assert step(node, "post_interrupt_iommu_passthrough_check.sh", env) != 0
-    assert said(node, "still resolves iommu.passthrough to 1"), output(node)
+    assert said(node, "resolves iommu.passthrough to '1' rather than 0"), output(node)
 
 
 def test_iommu_passthrough_post_interrupt_check_requires_translation_to_be_live(node):

--- a/tests/integration/nvidia_tuned/test_host_setup.py
+++ b/tests/integration/nvidia_tuned/test_host_setup.py
@@ -22,14 +22,15 @@ Tests for the nvidia-tuned host setup steps added for OCI GB300.
 Covers:
 - install_rdma_vfs_ready.sh, its config, post-interrupt, and uninstall checks
 - configure_pcie_acs.sh, its config and post-interrupt checks
+- configure_iommu_passthrough.sh, its config and post-interrupt checks
 - the bundled wait-rdma-vfs.sh helper
 
 Both steps self-gate on bundled assets resolved from the service and accelerator
 configmaps, so the no-op path for every other service/accelerator pair is covered too.
 
 These steps do not depend on the OS, so they run against a single base image rather
-than the package TEST_MATRIX. Real systemctl, rdma_topo, and update-grub are replaced
-by the test doubles in fakes/.
+than the package TEST_MATRIX. Real systemctl, rdma_topo, update-grub, and uname are
+replaced by the test doubles in fakes/.
 
 Assertions go through exit codes rather than captured text: a step's output is written
 to a file in the container and matched there with grep. The container exec API returns
@@ -55,6 +56,13 @@ OUTPUT_FILE = "/tmp/step-output"
 UNIT_DEST = "/etc/systemd/system/rdma-vfs-ready.service"
 HELPER_DEST = "/usr/local/sbin/wait-rdma-vfs.sh"
 ACS_DROPIN = "/etc/default/grub.d/config-acs.cfg"
+IOMMU_DROPIN = "/etc/default/grub.d/99-iommu-passthrough.cfg"
+FAKE_CMDLINE = "/tmp/fake-cmdline"
+FAKE_IOMMU_GROUPS = "/tmp/fake-iommu-groups"
+
+# Either side of the 6.11 threshold, where arm-smmu-v3 gained S1DSS_BYPASS.
+OLD_KERNEL = "6.8.0-1060-generic"
+NEW_KERNEL = "6.14.0-1015-generic"
 SYSTEMCTL_CALLS = "/tmp/fake-systemctl/calls"
 
 BUNDLED_DIR = "/skyhook-package/profiles/service/oci/rdma-vfs-ready-gb300"
@@ -682,3 +690,243 @@ def test_pcie_acs_rejects_unreadable_acs_state(node):
     # And it must not be reported as verified.
     assert step(node, "post_interrupt_pcie_acs_check.sh", unreadable) != 0
     assert said(node, "did not take effect on this node"), output(node)
+
+
+# ---------------------------------------------------------------------------
+# configure_iommu_passthrough.sh
+#
+# The policy turns on `uname -r`, so these pin it through the uname fake rather than
+# inheriting whatever kernel the test host happens to run.
+# ---------------------------------------------------------------------------
+
+
+def on_kernel(version: str, **extra) -> dict:
+    """Step env with the reported kernel version pinned."""
+    return {"FAKE_UNAME_R": version, **extra}
+
+
+def booted(node: DockerTestRunner, cmdline: str, *group_types: str) -> dict:
+    """Stage a fake booted state and return the env that points the check at it.
+
+    cmdline is written verbatim so a test can place iommu.passthrough more than once;
+    group_types become one sysfs group each, which is how translation is detected.
+    """
+    cmds = [f"printf '%s\\n' {shell_quote(cmdline)} > {FAKE_CMDLINE}",
+            f"rm -rf {FAKE_IOMMU_GROUPS}"]
+    for index, group_type in enumerate(group_types):
+        cmds.append(f"mkdir -p {FAKE_IOMMU_GROUPS}/{index}")
+        cmds.append(
+            f"printf '%s\\n' {shell_quote(group_type)} > {FAKE_IOMMU_GROUPS}/{index}/type"
+        )
+    assert sh(node, " && ".join(cmds)) == 0
+    return {"PROC_CMDLINE": FAKE_CMDLINE, "IOMMU_GROUPS_DIR": FAKE_IOMMU_GROUPS}
+
+
+@pytest.mark.parametrize("configmaps", OTHER_SHAPES, ids=OTHER_SHAPE_IDS)
+def test_iommu_passthrough_is_a_noop_without_the_opt_in_marker(node, configmaps):
+    configure(node, **configmaps)
+    old = on_kernel(OLD_KERNEL)
+
+    assert step(node, "configure_iommu_passthrough.sh", old) == 0, output(node)
+    assert said(node, "nothing to do"), output(node)
+    assert not exists(node, IOMMU_DROPIN)
+
+    for check in ("configure_iommu_passthrough_check.sh",
+                  "post_interrupt_iommu_passthrough_check.sh"):
+        assert step(node, check, old) == 0, output(node)
+        assert said(node, "nothing to verify"), output(node)
+
+
+def test_iommu_passthrough_writes_the_dropin_on_an_affected_kernel(node):
+    configure(node, **OCI_GB300)
+
+    assert step(node, "configure_iommu_passthrough.sh", on_kernel(OLD_KERNEL)) == 0
+    assert said(node, "reboot is required"), output(node)
+    assert contains(node, IOMMU_DROPIN, "iommu.passthrough=0")
+    assert exists(node, "/tmp/fake-grub/update-grub-ran")
+
+
+def test_iommu_passthrough_appends_rather_than_replacing(node):
+    """The drop-in must supersede an earlier producer without depending on one.
+
+    It contributes by appending to $GRUB_CMDLINE_LINUX, so it is correct whether or not
+    the platform ships a drop-in of its own, and sorts last so its value is the one the
+    kernel acts on.
+    """
+    configure(node, **OCI_GB300)
+
+    assert step(node, "configure_iommu_passthrough.sh", on_kernel(OLD_KERNEL)) == 0
+    assert contains(node, IOMMU_DROPIN, 'GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX')
+
+
+def test_iommu_passthrough_is_a_noop_on_a_fixed_kernel(node):
+    """At or above the threshold the kernel handles PASID on an identity domain."""
+    configure(node, **OCI_GB300)
+    new = on_kernel(NEW_KERNEL)
+
+    assert step(node, "configure_iommu_passthrough.sh", new) == 0, output(node)
+    assert said(node, "nothing to do"), output(node)
+    assert not exists(node, IOMMU_DROPIN)
+
+    for check in ("configure_iommu_passthrough_check.sh",
+                  "post_interrupt_iommu_passthrough_check.sh"):
+        assert step(node, check, new) == 0, output(node)
+
+
+def test_iommu_passthrough_is_idempotent_across_config_passes(node):
+    configure(node, **OCI_GB300)
+    old = on_kernel(OLD_KERNEL)
+
+    assert step(node, "configure_iommu_passthrough.sh", old) == 0, output(node)
+    assert sh(node, f"cp {IOMMU_DROPIN} /tmp/iommu-dropin.first") == 0
+    assert step(node, "configure_iommu_passthrough.sh", old) == 0, output(node)
+
+    assert said(node, "already current"), output(node)
+    assert same(node, "/tmp/iommu-dropin.first", IOMMU_DROPIN)
+
+
+def test_iommu_passthrough_rewrites_a_stale_dropin(node):
+    """A drop-in left by an older package version is corrected, not silently kept."""
+    configure(node, **OCI_GB300)
+    assert sh(node, "mkdir -p /etc/default/grub.d") == 0
+    assert sh(node, f"printf '%s\\n' '# stale' > {IOMMU_DROPIN}") == 0
+
+    assert step(node, "configure_iommu_passthrough.sh", on_kernel(OLD_KERNEL)) == 0
+    assert contains(node, IOMMU_DROPIN, "iommu.passthrough=0")
+
+
+@pytest.mark.parametrize("value", ["false", "FALSE", "0", "no", "off"])
+def test_iommu_passthrough_can_be_switched_off_by_the_operator(node, value):
+    """The escape hatch for a kernel carrying a backported fix uname cannot see."""
+    configure(node, **OCI_GB300)
+    off = on_kernel(OLD_KERNEL, CONFIGURE_IOMMU_PASSTHROUGH=value)
+
+    assert step(node, "configure_iommu_passthrough.sh", off) == 0, output(node)
+    assert said(node, "switched off"), output(node)
+    assert not exists(node, IOMMU_DROPIN)
+
+    # Both checks stand down, so a switched-off node never fails post-interrupt.
+    for check in ("configure_iommu_passthrough_check.sh",
+                  "post_interrupt_iommu_passthrough_check.sh"):
+        assert step(node, check, off) == 0, output(node)
+        assert said(node, "switched off"), output(node)
+
+
+@pytest.mark.parametrize("value", ["true", "TRUE", "1", "yes", "on"])
+def test_iommu_passthrough_can_be_forced_on_a_fixed_kernel(node, value):
+    """`true` overrides the version check, for a kernel auto reads wrongly."""
+    configure(node, **OCI_GB300)
+
+    rc = step(node, "configure_iommu_passthrough.sh",
+              on_kernel(NEW_KERNEL, CONFIGURE_IOMMU_PASSTHROUGH=value))
+    assert rc == 0, output(node)
+    assert said(node, "reboot is required"), output(node)
+    assert contains(node, IOMMU_DROPIN, "iommu.passthrough=0")
+
+
+def test_iommu_passthrough_treats_an_unparseable_kernel_as_new_enough(node):
+    """Applying a boot-affecting change to an unknown platform is the worse failure."""
+    configure(node, **OCI_GB300)
+
+    assert step(node, "configure_iommu_passthrough.sh", on_kernel("not-a-version")) == 0
+    assert said(node, "cannot parse kernel version"), output(node)
+    assert not exists(node, IOMMU_DROPIN)
+
+
+def test_iommu_passthrough_config_check_fails_when_nothing_was_written(node):
+    configure(node, **OCI_GB300)
+
+    assert step(node, "configure_iommu_passthrough_check.sh", on_kernel(OLD_KERNEL)) != 0
+    assert said(node, "no bootloader drop-in"), output(node)
+
+
+@pytest.mark.parametrize(
+    ("dropin", "accepted"),
+    [
+        ('GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX iommu.passthrough=0"', True),
+        ("iommu.passthrough=0", True),
+        ("\tiommu.passthrough=0", True),
+        ("# iommu.passthrough=0", False),
+        ("  # iommu.passthrough=0", False),
+        ('GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX" # iommu.passthrough=0', False),
+        ("# example only, nothing active here", False),
+    ],
+    ids=[
+        "assignment",
+        "bare",
+        "tab-indented",
+        "comment",
+        "indented-comment",
+        "inline-comment",
+        "no-token",
+    ],
+)
+def test_iommu_passthrough_config_check_only_accepts_an_active_setting(
+    node, dropin, accepted
+):
+    """A commented example must not satisfy the pre-reboot check, but indentation must."""
+    configure(node, **OCI_GB300)
+    assert sh(node, "mkdir -p /etc/default/grub.d") == 0
+    assert sh(node, f"printf '%s\\n' {shell_quote(dropin)} > {IOMMU_DROPIN}") == 0
+
+    rc = step(node, "configure_iommu_passthrough_check.sh", on_kernel(OLD_KERNEL))
+    if accepted:
+        assert rc == 0, output(node)
+        assert said(node, "pending reboot"), output(node)
+    else:
+        assert rc != 0, output(node)
+        assert said(node, "does not contain an active"), output(node)
+
+
+def test_iommu_passthrough_post_interrupt_check_accepts_a_translated_node(node):
+    configure(node, **OCI_GB300)
+    env = on_kernel(OLD_KERNEL,
+                    **booted(node, "root=x iommu.passthrough=1 quiet iommu.passthrough=0",
+                             "DMA-FQ", "DMA-FQ"))
+
+    assert step(node, "post_interrupt_iommu_passthrough_check.sh", env) == 0, output(node)
+    assert said(node, "translation is active"), output(node)
+
+
+def test_iommu_passthrough_post_interrupt_check_reads_the_last_cmdline_value(node):
+    """The token legitimately appears twice; only the last one is what the kernel used.
+
+    A drop-in that sorts before another producer leaves iommu.passthrough=1 in effect
+    while =0 is still present on the command line. Matching the token anywhere would
+    report that node as fixed, which is the failure this check exists to catch.
+    """
+    configure(node, **OCI_GB300)
+    env = on_kernel(OLD_KERNEL,
+                    **booted(node, "root=x iommu.passthrough=0 quiet iommu.passthrough=1",
+                             "identity", "identity"))
+
+    assert step(node, "post_interrupt_iommu_passthrough_check.sh", env) != 0
+    assert said(node, "still resolves iommu.passthrough to 1"), output(node)
+
+
+def test_iommu_passthrough_post_interrupt_check_requires_translation_to_be_live(node):
+    """A correct command line is not evidence on its own; the SMMU must have acted."""
+    configure(node, **OCI_GB300)
+    env = on_kernel(OLD_KERNEL,
+                    **booted(node, "root=x iommu.passthrough=1 quiet iommu.passthrough=0",
+                             "identity", "identity"))
+
+    assert step(node, "post_interrupt_iommu_passthrough_check.sh", env) != 0
+    assert said(node, "still in bypass"), output(node)
+
+
+def test_iommu_passthrough_failure_message_names_cause_impact_and_remedy(node):
+    """Whoever investigates the failure must not need to read the source to act."""
+    configure(node, **OCI_GB300)
+    env = on_kernel(OLD_KERNEL,
+                    **booted(node, "root=x iommu.passthrough=1", "identity"))
+
+    assert step(node, "post_interrupt_iommu_passthrough_check.sh", env) != 0
+
+    # Cause: the workaround did not reach the booted kernel.
+    assert said(node, "did not take effect on this node"), output(node)
+    # Impact: no CUDA context can be created, and where to look to confirm.
+    assert said(node, "NO CUDA context"), output(node)
+    assert said(node, "arm_smmu_write_ctx_desc"), output(node)
+    # Remedy: the documented opt-out.
+    assert said(node, "CONFIGURE_IOMMU_PASSTHROUGH=false"), output(node)

--- a/tests/integration/nvidia_tuned/test_host_setup.py
+++ b/tests/integration/nvidia_tuned/test_host_setup.py
@@ -1061,3 +1061,34 @@ def test_iommu_passthrough_uninstall_runs_regardless_of_the_profile_gate(node):
     configure(node, accelerator="h100", service="eks")
     assert step(node, "uninstall_iommu_passthrough.sh") == 0, output(node)
     assert not exists(node, IOMMU_DROPIN)
+
+
+def test_iommu_passthrough_restores_the_dropin_when_grub_regeneration_fails(node):
+    """A failed regeneration must not leave the drop-in deleted.
+
+    The generated bootloader config still carries iommu.passthrough=0 at that point, so
+    dropping the source file would make the next uninstall report success against a node
+    that still boots with the setting and has nothing left to remove.
+    """
+    configure(node, **OCI_GB300)
+    assert step(node, "configure_iommu_passthrough.sh", on_kernel(OLD_KERNEL)) == 0
+    assert exists(node, IOMMU_DROPIN)
+
+    assert step(node, "uninstall_iommu_passthrough.sh", {"FAKE_GRUB_FAIL": "1"}) != 0
+    assert said(node, "restored"), output(node)
+    assert exists(node, IOMMU_DROPIN)
+
+    # The check must agree the uninstall did not finish.
+    assert step(node, "uninstall_iommu_passthrough_check.sh") != 0, output(node)
+    assert said(node, "still present"), output(node)
+
+
+def test_iommu_passthrough_removes_the_dropin_when_grub_regeneration_fails_on_write(node):
+    """Symmetrically, a drop-in must not outlive a failed regeneration on the write path."""
+    configure(node, **OCI_GB300)
+
+    rc = step(node, "configure_iommu_passthrough.sh",
+              on_kernel(OLD_KERNEL, FAKE_GRUB_FAIL="1"))
+    assert rc != 0, output(node)
+    assert said(node, "could not regenerate"), output(node)
+    assert not exists(node, IOMMU_DROPIN)

--- a/tests/integration/nvidia_tuned/test_spcx_cc.py
+++ b/tests/integration/nvidia_tuned/test_spcx_cc.py
@@ -564,3 +564,43 @@ def test_spcx_cc_off_tolerates_processes_owned_by_something_else(node):
     assert step(node, "configure_spcx_cc_check.sh") == 0, output(node)
     assert said(node, "is off"), output(node)
     assert said(node, "running from outside this package"), output(node)
+
+
+def test_spcx_cc_uninstall_check_ignores_not_found_stubs(node):
+    """A successful uninstall leaves not-found stubs, and they must not fail the check.
+
+    Removing the template unit file is what makes each instance not-found, and systemd
+    keeps them enumerated under `--all` until they are garbage collected. The device
+    units udev created still reference them, so they survive daemon-reload, and
+    reset-failed does not clear them because they are inactive/dead rather than failed.
+    Counting them made the check unpassable on a node that had actually been cleaned up,
+    which blocked every nvidia-tuned upgrade.
+    """
+    configure(node, spcx_cc="on", **OCI_GB300)
+    stage_rails(node)
+    assert step(node, "configure_spcx_cc.sh") == 0, output(node)
+    assert step(node, "uninstall_spcx_cc.sh") == 0, output(node)
+
+    # What the node looks like afterwards: unit file and rule gone, stubs still listed.
+    for rail in ("mlx5_bond_0", "mlx5_bond_1"):
+        unit = f"doca-spcx-cc@{rail}.service"
+        assert sh(node, f"touch /tmp/fake-systemctl/stub.{unit}") == 0
+
+    assert step(node, "uninstall_spcx_cc_check.sh") == 0, output(node)
+    assert said(node, "units are removed"), output(node)
+
+
+def test_spcx_cc_uninstall_check_still_fails_on_a_loaded_unit(node):
+    """Ignoring not-found must not weaken the assertion for a unit that is still loaded."""
+    configure(node, spcx_cc="on", **OCI_GB300)
+    stage_rails(node)
+    assert step(node, "configure_spcx_cc.sh") == 0, output(node)
+    assert step(node, "uninstall_spcx_cc.sh") == 0, output(node)
+
+    # A still-loaded instance is a real uninstall failure, stub or not.
+    assert sh(node, "touch /tmp/fake-systemctl/active.doca-spcx-cc@mlx5_bond_0.service") == 0
+    assert sh(node, "touch /tmp/fake-systemctl/stub.doca-spcx-cc@mlx5_bond_1.service") == 0
+
+    assert step(node, "uninstall_spcx_cc_check.sh") != 0, output(node)
+    assert said(node, "still known to systemd"), output(node)
+    assert said(node, "doca-spcx-cc@mlx5_bond_0.service"), output(node)


### PR DESCRIPTION
## What

Adds a `configure-iommu-passthrough` step to `nvidia-tuned`, needed to run ACS + DMA-BUF on kernels older than 6.11.

`arm-smmu-v3` before 6.11 cannot attach a PASID to an identity domain. Under `iommu.passthrough=1` the master's context descriptor table is never allocated (`arm_smmu_alloc_cd_tables()` is only reached for a stage-1 translating domain), so `cd_table->s1cdmax` stays 0 and `nvidia_uvm`'s ATS/SVA bind trips:

```
WARN_ON(ssid >= (1 << cd_table->s1cdmax))   ->  -E2BIG
  arm_smmu_write_ctx_desc
  arm_smmu_sva_set_dev_pasid
  iommu_sva_bind_device
  uvm_ats_bind_gpu                 [nvidia_uvm]
  uvm_va_space_register_gpu_va_space [nvidia_uvm]
```

The user-visible effect is that **no CUDA context can be created at all when ACS is enabled**: `cudaMalloc` reports the GPUs as busy on a node with nothing running on them, so DCGM, the GPU operator validators and every workload fail together. 

Setting `iommu.passthrough=0` restores translating (DMA-FQ) domains, the CD table is allocated, the bind succeeds, and CUDA, GPUDirect RDMA and the DMA-BUF path the ACS correction sets up all work.

## Threshold

Upstream fixed this in two steps: 6.10 made CD tables allocate-on-demand, and 6.11 added `STRTAB_STE_1_S1DSS_BYPASS` (PASID on an identity STE). 6.11 is the threshold.

## Behaviour

- Gated on `profiles/service/${service}/iommu-passthrough-${accelerator}.enabled`, so pairs without the marker are a no-op. Today only `oci` + `gb300`.
- One operator knob, `CONFIGURE_IOMMU_PASSTHROUGH`: `auto` (default, apply below 6.11), `true` (always), `false` (never, skips the checks). Mirrors `CONFIGURE_PCIE_ACS`.
- `auto` reads `uname -r`, and vendor kernels backport, so it can guess wrong in both directions. Detecting a backported fix requires the GPU driver to be loaded, which deadlocks bringup, so the explicit values are the escape hatch.
- Writes `/etc/default/grub.d/99-iommu-passthrough.cfg`. Appends to `$GRUB_CMDLINE_LINUX` and sorts last, so it supersedes an earlier producer **without depending on one existing**.
- Independent of the ACS correction; both are active together.

## Notes for review

- **Duplicated helpers across the three scripts** (`iommu_enabled`, `iommu_policy`, `kernel_predates_fix`) are deliberate: this mirrors `acs_enabled`/`acs_requested` in the ACS scripts. Each step runs as a standalone process.
- **The post-interrupt check reads the *last* `iommu.passthrough` value** on the command line rather than grepping for the token. The value legitimately appears twice (platform sets 1, this drop-in appends 0); it is an `early_param` and `do_early_param()` runs the handler per occurrence in order, so only the last applies. A `grep iommu.passthrough=0` would pass even when something later set it back to 1.
- **Translation is verified via sysfs group type**, not the dmesg `Default domain type:` line, which can wrap out of the ring buffer.
- **Tests** cover marker gating, the version policy either side of the threshold, explicit true/false overrides, idempotent re-runs, stale drop-in replacement, an unparseable kernel version, the active-vs-commented matcher, drop-in removal when the policy stands down, and the three post-interrupt outcomes. A `uname` test double pins the kernel version the policy sees.
- **Uninstall removes the drop-in**, unlike `configure_pcie_acs.sh`, which deliberately leaves its own in place. The ACS drop-in corrects a hardware misconfiguration and reverting it would degrade RDMA; this one is purely a workaround, so removing it restores the platform's own setting. It runs unconditionally rather than self-gating on the marker, matching `uninstall_rdma_vfs_ready.sh`, so it also cleans up after a re-profiled custom resource.

## Also in this PR: spcx-cc uninstall check fix

Folded in rather than shipped separately, because the bug persists into 0.8.0 and would
otherwise strand the next upgrade away from this release.

`uninstall_spcx_cc_check.sh` failed on nodes where the uninstall had fully succeeded.
Removing the template unit file is what makes each instance `not-found`, and systemd keeps
those stubs enumerated under `systemctl list-units --all` until they are garbage collected.
The infiniband device units udev created still carry `Wants=doca-spcx-cc@<rail>.service`
from `SYSTEMD_WANTS`, computed at device-add time and not recomputed when the rule file is
deleted, so the stubs survive `daemon-reload`. `reset-failed` does not clear them either,
because they are inactive/dead rather than failed.

The check counted any listed instance, so a node whose units, unit file and udev rule had
all been removed could never pass, and the uninstall retried until it backed off. This was
hit in practice: it blocked an nvidia-tuned upgrade across a GB300 pool, with the unit
file, udev rule and processes all confirmed gone and only `not-found inactive dead` stubs
remaining.

The check now ignores instances whose LOAD column reads `not-found`; a still-loaded unit
remains a failure. The `systemctl` double grows a `stub.<unit>` marker so both outcomes are
covered.

Note this fix only takes effect for upgrades away from a release that contains it, since
skyhook runs the installed version's uninstall scripts.

## Testing

Verified on affected hardware: a node that could not create a CUDA context came up healthy after the change, with DMA-BUF active in a multi-node NCCL all_reduce and collective bandwidth in line with an unaffected node. The ACS correction remained in place throughout.



---

Re-opened from a branch on this repository rather than a fork, so the PR build publishes a `0.8.0-dev.<sha>` image for hardware testing; fork PRs skip the push. Supersedes #121, which carries the earlier review history: four CodeRabbit findings, three fixed and one withdrawn after the idempotence comparison was shown to already hold.

