### PR TITLE
fix(tuning): update tuning package check script to work with older versions of bash

### DIFF
--- a/tests/integration/tuning/test_update_settings_check.py
+++ b/tests/integration/tuning/test_update_settings_check.py
@@ -44,6 +44,12 @@ from tests.helpers.docker_test import DockerTestRunner
 SKYHOOK_RESOURCE_ID = "1_tuning_1.1.5"
 PACKAGE_NAME_FROM_RESOURCE_ID = "tuning"
 SYSCTL_DROP_IN = f"/etc/sysctl.d/999-{PACKAGE_NAME_FROM_RESOURCE_ID}-tuning.conf"
+BASH_4_2_BASE_IMAGE = "centos:7"
+
+MULTILINE_SYSCTL = (
+    "fs.inotify.max_user_watches=1048576\n"
+    "fs.inotify.max_user_instances=65535\n"
+)
 
 # Reproduces nvidia-tuning-gke/profiles/h100/inference/sysctl.conf exactly,
 # including the comment header containing "[sysctl]" that broke the check
@@ -115,6 +121,19 @@ def test_check_succeeds_with_h100_style_comment_containing_brackets(base_image):
     `not in sysctl: # H100 inference ...` and exited 1.
     """
     runner = _start_container_with_configmaps(base_image, H100_INFERENCE_SYSCTL)
+    try:
+        _simulate_install_copy(runner)
+        result = _run_check(runner)
+        output = result.output.decode("utf-8", errors="replace")
+        assert result.exit_code == 0, f"check exited non-zero:\n{output}"
+        assert "not in sysctl:" not in output, output
+    finally:
+        runner.cleanup()
+
+
+def test_check_preserves_multiline_sysctl_input_on_bash_4_2():
+    """Regression: Bash 4.2 must check each sysctl assignment separately."""
+    runner = _start_container_with_configmaps(BASH_4_2_BASE_IMAGE, MULTILINE_SYSCTL)
     try:
         _simulate_install_copy(runner)
         result = _run_check(runner)

--- a/tuning/config.json
+++ b/tuning/config.json
@@ -1,7 +1,7 @@
 {
     "schema_version": "v1",
     "package_name": "tuning",
-    "package_version": "1.1.6",
+    "package_version": "1.1.7",
     "expected_config_files": [],
     "modes": {
         "config": [

--- a/tuning/skyhook_dir/update_settings_check.sh
+++ b/tuning/skyhook_dir/update_settings_check.sh
@@ -41,7 +41,7 @@ if [ -f ${SKYHOOK_DIR}/configmaps/sysctl.conf ]; then
         if [ $(grep -cF "${line}" /etc/sysctl.d/999-${package_name}-tuning.conf) -eq 0 ]; then
             failures=$(printf "%s\n%s" "$failures" "not in sysctl: ${line}")
         fi
-    done  <<< $(grep -vE '^[[:space:]]*(#|$)' ${SKYHOOK_DIR}/configmaps/sysctl.conf)
+    done < <(grep -vE '^[[:space:]]*(#|$)' "${SKYHOOK_DIR}/configmaps/sysctl.conf")
 fi
 
 if [ -f ${SKYHOOK_DIR}/configmaps/ulimit.conf ]; then
@@ -53,7 +53,7 @@ if [ -f ${SKYHOOK_DIR}/configmaps/ulimit.conf ]; then
         if [ $(grep -cF "hard ${name} ${value}" /etc/security/limits.d/999-${package_name}-tuning.conf) -eq 0 ]; then
             failures=$(printf "%s\n%s" "$failures" "No ${line} setting in /etc/security/limits.d/999-${package_name}-tuning.conf")
         fi
-    done  <<< $(grep -vE '^[[:space:]]*(#|$)' ${SKYHOOK_DIR}/configmaps/ulimit.conf)
+    done < <(grep -vE '^[[:space:]]*(#|$)' "${SKYHOOK_DIR}/configmaps/ulimit.conf")
 fi
 
 if [ -n "$failures" ]; then


### PR DESCRIPTION
## Description
In practice, I found that the check script, when running in an OS that has bash 4.2 installed, will present multiple sysctl changes as though they are on one line instead of one setting per line (as would be expected). This change should work on older versions of bash as well as more recent editions. Also added a behavior test for the problem.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nodewright-packages/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
