### PR TITLE
feat(nvidia-tuned): add rke2 service keeping the accelerator's bootloader tuning

### DIFF
--- a/nvidia-tuned/README.md
+++ b/nvidia-tuned/README.md
@@ -20,7 +20,8 @@ This package requires **tuned >= 2.19**. The following operating systems are sup
 > profiles live under `profiles/os/ubuntu/26.04/`. The base profiles keep the
 > reboot-requiring `[bootloader]` tuning (same as gb200); with `service=bcm`, vr200
 > uses a bootloader-free profile chain (`nvidia-vr200-noreboot-base`) so the tuning
-> applies without a reboot. There is no `service=eks` vr200 profile yet.
+> applies without a reboot. Use `service=rke2` instead to keep that tuning and take a
+> reboot for it. There is no `service=eks` vr200 profile.
 
 | OS | Version | Status | Notes |
 |----|---------|--------|-------|
@@ -75,6 +76,9 @@ profiles/
     │   ├── tuned.conf.template
     │   ├── script.sh            # Sources common/mac-address-policy.sh, invokes common/bootloader.sh
     │   └── nvidia-h100-inference.conf   # AKS-compatible inference override (drops kernel-6.8 EEVDF sysctls)
+    ├── rke2/
+    │   ├── tuned.conf.template  # No [script], no overrides: accelerators fall through with [bootloader] intact
+    │   └── bootloader.enabled   # Opts the service in to the configure-bootloader lifecycle step
     └── oci/
         ├── tuned.conf.template  # RDMA IPv6 defaults for OCI's IPv6/SLAAC RoCE fabric
         ├── script.sh            # Re-enables IPv6 on existing mlx5 RDMA VFs
@@ -317,6 +321,72 @@ host-level steps do need a reboot:
 Both steps are no-ops for every other `service`/`accelerator` pair, so existing `eks`,
 `aks`, and `bcm` deployments are unaffected and still need no `interrupt`.
 
+**RKE2 tuning** (VR200 on RKE2: keeps the profile's kernel command line, takes a reboot):
+
+```yaml
+apiVersion: skyhook.nvidia.com/v1alpha1
+kind: Skyhook
+metadata:
+  name: nvidia-tuned-rke2
+spec:
+  nodeSelectors:
+    matchLabels:
+      nvidia.com/gpu.present: "true"
+  packages:
+    nvidia-tuned:
+      image: ghcr.io/nvidia/nodewright-packages/nvidia-tuned
+      version: 0.9.0
+      interrupt:
+        type: reboot
+      configInterrupts:
+        intent:
+          type: reboot
+        accelerator:
+          type: reboot
+      configMap:
+        intent: performance
+        accelerator: vr200
+        service: rke2
+```
+
+`interrupt: {type: reboot}` is required. Where `bcm` re-roots vr200 onto a
+bootloader-free base so nothing needs a reboot, `rke2` is the opposite trade: it ships no
+profile overrides at all, so each accelerator falls through to its own workload profile
+with the `[bootloader]` stanza intact, and the node reboots to pick it up.
+
+Keeping the stanza is not enough on its own. tuned resolves it to
+`/etc/tuned/bootcmdline` and then rewrites `/etc/default/grub`, but Ubuntu assembles
+`GRUB_CMDLINE_LINUX_DEFAULT` from `/etc/default/grub.d/` instead, so that rewrite is
+ignored and the cmdline silently never applies. The `configure-bootloader` step closes
+that gap: it writes a `/etc/default/grub.d/99-nvidia-tuned-cmdline.cfg` drop-in sourcing
+tuned's file, then regenerates grub. It appends to `GRUB_CMDLINE_LINUX_DEFAULT` rather
+than replacing it, so the platform's own arguments (serial console, most importantly)
+survive. The step is gated on `profiles/service/{service}/bootloader.enabled` and is a
+no-op for every service that does not ship the marker, so `eks`, `aks`, `bcm`, and `oci`
+are unaffected. It uses its own filename rather than the `99_tuned.cfg` the `eks` and
+`aks` profiles write, and only ever removes a file carrying its own marker line, so it
+cannot disturb theirs.
+
+After the reboot, `post-interrupt-bootloader-check` asserts every argument in
+`/etc/tuned/bootcmdline` is present in `/proc/cmdline`. This is the check worth having:
+grub quietly failing to pick the drop-in up is invisible from the config stage, and
+without it a node comes up labelled as tuned while running none of the tuning.
+
+Uninstalling removes the drop-in and regenerates grub, so the cmdline goes away on the
+next boot rather than outliving the package.
+
+> **Accelerator support:** the service ships no accelerator-specific files, so support is
+> exactly whatever workload profiles exist. `gb200` and `vr200` work across all three
+> intents; `gb300` ships a `performance` profile only, so that is the only intent
+> available there (this is a property of the accelerator, not of `rke2`). `vr200`
+> remains Ubuntu 26.04 only.
+>
+> | Accelerator | `performance` | `inference` | `multiNodeTraining` |
+> |---|---|---|---|
+> | `gb200` | yes | yes | yes |
+> | `gb300` | yes | no profile | no profile |
+> | `vr200` | yes | yes | yes |
+
 ### ConfigMap Fields
 
 | Field | Required | Default | Description |
@@ -354,6 +424,7 @@ Both steps are no-ops for every other `service`/`accelerator` pair, so existing 
 | `h100` | NVIDIA H100 GPU |
 | `gb200` | NVIDIA GB200 GPU |
 | `gb300` | NVIDIA GB300 GPU (`performance` intent only) |
+| `vr200` | NVIDIA VR200 GPU (Ubuntu 26.04 only) |
 
 ### Services (specify in `service`)
 
@@ -362,6 +433,7 @@ Both steps are no-ops for every other `service`/`accelerator` pair, so existing 
 | `eks` | eks-specific settings (MAC address policy for CNI) |
 | `aks` | aks-specific settings (MAC address policy, grub.d bootloader workaround for Ubuntu) |
 | `bcm` | bcm-specific settings (bootloader-free vr200 chain, applies without a reboot) |
+| `rke2` | rke2-specific settings (keeps the accelerator's `[bootloader]` tuning and lands it on the host through grub.d; requires `interrupt: {type: reboot}`) |
 | `oci` | oci-specific settings (RDMA IPv6 defaults, NCCL topology file, PCIe ACS correction, RDMA VF boot gate, and Spectrum-X congestion control on gb300; requires `interrupt: {type: reboot}`) |
 
 ### Environment Variables
@@ -427,7 +499,7 @@ See the [tuned package README](../tuned/README.md) for complete documentation on
 
 ## Version
 
-- **Package Version**: 0.7.1
+- **Package Version**: 0.9.0
 - **Base Package**: tuned (latest via preprocess.sh)
 - **Schema Version**: v1
 

--- a/nvidia-tuned/README.md
+++ b/nvidia-tuned/README.md
@@ -375,6 +375,17 @@ without it a node comes up labelled as tuned while running none of the tuning.
 Uninstalling removes the drop-in and regenerates grub, so the cmdline goes away on the
 next boot rather than outliving the package.
 
+The step is **Debian-family only**, and fails on anything else rather than passing
+quietly. Sourcing `/etc/default/grub.d/*.cfg` is a Debian/Ubuntu patch to
+`grub-mkconfig`; RHEL-family `grub2-mkconfig` reads `/etc/default/grub` and
+`/etc/grub.d/` and ignores that directory entirely. On a RHEL-family node the drop-in
+would be written, GRUB would regenerate without error, and none of the arguments would
+reach the kernel, so the node would report success while running none of its tuning.
+Because the package falls back to `os/common` profiles on untested distributions, the
+step cannot assume an OS gate happened upstream and checks `ID`/`ID_LIKE` itself. On such
+a node, either use `service=bcm` (same accelerators, bootloader-free chain, no reboot) or
+set `CONFIGURE_BOOTLOADER=false` and set the kernel arguments by another route.
+
 > **Accelerator support:** the service ships no accelerator-specific files, so support is
 > exactly whatever workload profiles exist. `gb200` and `vr200` work across all three
 > intents; `gb300` ships a `performance` profile only, so that is the only intent
@@ -443,6 +454,7 @@ next boot rather than outliving the package.
 | `TOPO_PATH` | No | `/etc/nccl/topo.xml` | Absolute host path the bundled NCCL topology file is written to. Only used when the configured `service`/`accelerator` pair ships one (today `oci` + `gb300`); otherwise the step is a no-op. Point `NCCL_TOPO_FILE` at the same path in your workloads. |
 | `CONFIGURE_PCIE_ACS` | No | `true` | Set to `false` to skip the PCIe ACS correction and its checks. Only relevant to a `service`/`accelerator` pair that opts in (today `oci` + `gb300`). Use this on nodes whose kernel does not honour `pci=config_acs=`, where the correction cannot take effect and the post-interrupt check would otherwise fail the node. |
 | `CONFIGURE_IOMMU_PASSTHROUGH` | No | `auto` | Controls the IOMMU passthrough workaround for kernels whose arm-smmu-v3 cannot attach a PASID to an identity domain. `auto` applies it only when the running kernel is older than 6.11; `true` always applies it; `false` never does and skips the checks. Only relevant to a `service`/`accelerator` pair that opts in (today `oci` + `gb300`). Set `false` on a node whose kernel carries a backported fix that the version check cannot see. |
+| `CONFIGURE_BOOTLOADER` | No | `true` | Set to `false` to skip the bootloader drop-in step and all three of its checks. Only relevant to a service that ships `bootloader.enabled` (today `rke2`). Use it on a node whose kernel arguments are owned by something else, and on any RHEL-family node, where the step fails by design (see the RKE2 tuning section above). |
 | `APT_ALLOW_INDEX_FAILURE` | No | `true` | Inherited from the `tuned` base package. Lets `apt update` fail without failing the install step, so one unreachable third-party repo in `/etc/apt/sources.list.d` cannot block the package. Set to `false` to restore strict behavior. The `apt install` that follows is unaffected and still fails if the package is genuinely unavailable. |
 
 ## Adding OS-Specific Overrides

--- a/nvidia-tuned/RELEASE_NOTES.md
+++ b/nvidia-tuned/RELEASE_NOTES.md
@@ -48,6 +48,15 @@ suppresses the `containerd_service.sh` that the gb200 and vr200 performance prof
 carry. Operators on `eks` with `gb200` are hitting that today; `rke2` avoids it by
 shipping no `[script]` at all.
 
+The step is Debian-family only and fails on anything else. Sourcing
+`/etc/default/grub.d/*.cfg` is a Debian/Ubuntu patch to `grub-mkconfig`; RHEL-family
+`grub2-mkconfig` ignores that directory, so the drop-in would be written, GRUB would
+regenerate without error, and nothing would reach the kernel. Since this package falls
+back to `os/common` profiles on untested distributions, the step checks `ID`/`ID_LIKE`
+itself rather than assuming an OS gate upstream. Set `CONFIGURE_BOOTLOADER=false` to skip
+the step and its checks on such a node, or use `service=bcm` for a bootloader-free chain
+on the same accelerators.
+
 New `post-interrupt-bootloader-check` asserts every argument in `/etc/tuned/bootcmdline`
 is present in `/proc/cmdline` after the reboot. Grub failing to pick the drop-in up is
 invisible from the config stage, so without this a node comes up reporting success while

--- a/nvidia-tuned/RELEASE_NOTES.md
+++ b/nvidia-tuned/RELEASE_NOTES.md
@@ -20,6 +20,45 @@ example is not itself picked up as release notes):
     - Notable behavior change worth calling out.
 -->
 
+## 0.9.0
+
+Adds an `rke2` service that keeps the accelerator's reboot-requiring `[bootloader]`
+tuning instead of stripping it, and a `configure-bootloader` step that actually lands it
+on the host.
+
+`bcm` and `rke2` are the two halves of the same trade for the same accelerators. `bcm`
+re-roots onto a bootloader-free base so nothing needs a reboot; `rke2` ships no profile
+overrides at all, so each accelerator falls through to its own workload profile with the
+`[bootloader]` stanza intact. A custom resource selecting `service=rke2` must therefore
+declare `interrupt: {type: reboot}`. Supported on `gb200` and `vr200` across all three
+intents, and on `gb300` for `performance` (the only intent that accelerator ships).
+
+Keeping the stanza is not sufficient by itself. tuned resolves it to
+`/etc/tuned/bootcmdline` and then rewrites `/etc/default/grub`, but Ubuntu builds
+`GRUB_CMDLINE_LINUX_DEFAULT` from `/etc/default/grub.d/`, so that rewrite is ignored and
+the cmdline never reaches the kernel. The new `configure-bootloader` step writes a
+`99-nvidia-tuned-cmdline.cfg` drop-in sourcing tuned's file and regenerates grub. Unlike
+the older in-profile script the `eks` and `aks` services use, it appends to
+`GRUB_CMDLINE_LINUX_DEFAULT` rather than replacing it, so a bare-metal host keeps its
+serial console arguments.
+
+The step runs as a package lifecycle step rather than a tuned `[script]` on purpose. Only
+one `[script]` survives tuned's include chain, so a service profile that declares one
+suppresses the `containerd_service.sh` that the gb200 and vr200 performance profiles
+carry. Operators on `eks` with `gb200` are hitting that today; `rke2` avoids it by
+shipping no `[script]` at all.
+
+New `post-interrupt-bootloader-check` asserts every argument in `/etc/tuned/bootcmdline`
+is present in `/proc/cmdline` after the reboot. Grub failing to pick the drop-in up is
+invisible from the config stage, so without this a node comes up reporting success while
+running none of the tuning it was selected for.
+
+Uninstall removes the drop-in and regenerates grub, so the cmdline does not outlive the
+package. Both the removal here and the stand-down when a node stops selecting an opted-in
+service are scoped to a marker line the step writes, and the file has its own name rather
+than the `99_tuned.cfg` the `eks` and `aks` profiles write. Nothing this release adds can
+remove or overwrite a drop-in those services own; their behavior is unchanged.
+
 ## 0.8.0
 
 Adds an IOMMU passthrough workaround needed to run ACS + DMA-BUF on kernels older than

--- a/nvidia-tuned/config.json
+++ b/nvidia-tuned/config.json
@@ -1,7 +1,7 @@
 {
     "schema_version": "v1",
     "package_name": "nvidia_tuned",
-    "package_version": "0.8.0",
+    "package_version": "0.9.0",
     "expected_config_files": [
         "accelerator"
     ],
@@ -34,6 +34,18 @@
             {
                 "name": "uninstall-iommu-passthrough",
                 "path": "uninstall_iommu_passthrough.sh",
+                "arguments": [],
+                "returncodes": [
+                    0
+                ],
+                "on_host": true,
+                "env": {},
+                "idempotence": true,
+                "upgrade_step": false
+            },
+            {
+                "name": "uninstall-bootloader",
+                "path": "uninstall_bootloader.sh",
                 "arguments": [],
                 "returncodes": [
                     0
@@ -84,6 +96,18 @@
             {
                 "name": "uninstall-iommu-passthrough-check",
                 "path": "uninstall_iommu_passthrough_check.sh",
+                "arguments": [],
+                "returncodes": [
+                    0
+                ],
+                "on_host": true,
+                "env": {},
+                "idempotence": true,
+                "upgrade_step": false
+            },
+            {
+                "name": "uninstall-bootloader-check",
+                "path": "uninstall_bootloader_check.sh",
                 "arguments": [],
                 "returncodes": [
                     0
@@ -246,6 +270,18 @@
                 "env": {},
                 "idempotence": true,
                 "upgrade_step": false
+            },
+            {
+                "name": "configure-bootloader",
+                "path": "configure_bootloader.sh",
+                "arguments": [],
+                "returncodes": [
+                    0
+                ],
+                "on_host": true,
+                "env": {},
+                "idempotence": false,
+                "upgrade_step": false
             }
         ],
         "config-check": [
@@ -332,6 +368,18 @@
                 "env": {},
                 "idempotence": true,
                 "upgrade_step": false
+            },
+            {
+                "name": "configure-bootloader-check",
+                "path": "configure_bootloader_check.sh",
+                "arguments": [],
+                "returncodes": [
+                    0
+                ],
+                "on_host": true,
+                "env": {},
+                "idempotence": true,
+                "upgrade_step": false
             }
         ],
         "post-interrupt-check": [
@@ -362,6 +410,18 @@
             {
                 "name": "post-interrupt-iommu-passthrough-check",
                 "path": "post_interrupt_iommu_passthrough_check.sh",
+                "arguments": [],
+                "returncodes": [
+                    0
+                ],
+                "on_host": true,
+                "env": {},
+                "idempotence": true,
+                "upgrade_step": false
+            },
+            {
+                "name": "post-interrupt-bootloader-check",
+                "path": "post_interrupt_bootloader_check.sh",
                 "arguments": [],
                 "returncodes": [
                     0

--- a/nvidia-tuned/profiles/service/rke2/bootloader.enabled
+++ b/nvidia-tuned/profiles/service/rke2/bootloader.enabled
@@ -1,0 +1,12 @@
+# Marker: opt this service in to the grub.d bootloader step run by
+# skyhook_dir/configure_bootloader.sh. The file is a switch; its contents are ignored.
+#
+# Unlike the pcie-acs-* and iommu-passthrough-* markers this one is service-wide rather
+# than per-accelerator: every accelerator reached through this service wants its
+# [bootloader] cmdline on the host, so there is nothing to select between.
+#
+# Ubuntu builds its kernel command line from /etc/default/grub.d/ rather than the
+# /etc/default/grub rewrite tuned performs itself, so without the drop-in this step
+# writes, a profile's [bootloader] stanza never reaches the booted kernel. Landing on the
+# kernel command line means a custom resource selecting this service must declare
+# `interrupt: {type: reboot}`.

--- a/nvidia-tuned/profiles/service/rke2/tuned.conf.template
+++ b/nvidia-tuned/profiles/service/rke2/tuned.conf.template
@@ -1,0 +1,17 @@
+[main]
+summary=NVIDIA RKE2 service profile: keeps the accelerator's bootloader tuning
+
+# RKE2 runs on hosts the operator owns outright, so unlike bcm this service keeps the
+# reboot-requiring [bootloader] tuning its accelerator profile carries rather than
+# re-rooting onto a bootloader-free base. A custom resource selecting service=rke2 must
+# therefore declare `interrupt: {type: reboot}`.
+#
+# No accelerator overrides ship alongside this template on purpose: with no
+# nvidia-{accelerator}-{intent}.conf in this directory, deploy_service_profile() includes
+# the OS workload profile unchanged, so every accelerator falls through with its own
+# [bootloader] stanza intact.
+#
+# No [script] here on purpose either: only one [script] survives tuned's include chain,
+# so a stanza here would suppress the containerd_service.sh that the gb200 and vr200
+# performance profiles carry. The grub.d work this service needs runs as the
+# configure-bootloader lifecycle step instead (skyhook_dir/configure_bootloader.sh).

--- a/nvidia-tuned/skyhook_dir/configure_bootloader.sh
+++ b/nvidia-tuned/skyhook_dir/configure_bootloader.sh
@@ -24,6 +24,15 @@
 # is ignored and the profile's cmdline silently never applies. This step writes a
 # /etc/default/grub.d/ drop-in that sources tuned's file, then regenerates grub.
 #
+# DEBIAN-FAMILY ONLY. Sourcing /etc/default/grub.d/*.cfg is a Debian/Ubuntu patch to
+# grub-mkconfig. RHEL-family grub2-mkconfig reads /etc/default/grub and /etc/grub.d/ and
+# ignores that directory entirely, so the drop-in would be written, grub would regenerate
+# happily, and the arguments would never reach the kernel. The package as a whole falls
+# back to os/common profiles on untested distributions, so this step cannot assume the
+# OS gate happened upstream and checks for itself. It fails rather than skipping quietly:
+# a node that reports success while running none of the tuning it was selected for is the
+# worse outcome. Set CONFIGURE_BOOTLOADER=false to opt out deliberately.
+#
 # Gated on ${SKYHOOK_DIR}/profiles/service/${service}/bootloader.enabled, so services
 # without the marker are a no-op. The marker is service-wide rather than per-accelerator:
 # every accelerator reached through such a service wants its cmdline on the host.
@@ -41,8 +50,14 @@ PROFILES_DIR="${SKYHOOK_DIR}/profiles"
 # Overridable so tests can point at a stub.
 TUNED_GRUB_DROPIN="${TUNED_GRUB_DROPIN:-/etc/default/grub.d/99-nvidia-tuned-cmdline.cfg}"
 TUNED_BOOTCMDLINE="${TUNED_BOOTCMDLINE:-/etc/tuned/bootcmdline}"
+OS_RELEASE="${OS_RELEASE:-/etc/os-release}"
 
-# 99_ sorts after every numbered producer, so this assignment is evaluated last and its
+# Identifies a drop-in this package owns. The eks and aks services write their own
+# grub.d file from inside the tuned profile; scoping removal to our marker keeps this
+# step from deleting theirs when it stands down on a node running one of them.
+DROPIN_MARKER="Managed by the nvidia-tuned Skyhook package (configure_bootloader.sh)"
+
+# 99- sorts after every numbered producer, so this assignment is evaluated last and its
 # arguments win where a token is set twice.
 #
 # Appends to GRUB_CMDLINE_LINUX_DEFAULT rather than replacing it, which is where this
@@ -57,7 +72,7 @@ TUNED_BOOTCMDLINE="${TUNED_BOOTCMDLINE:-/etc/tuned/bootcmdline}"
 # Unquoted heredoc: ${TUNED_BOOTCMDLINE} is baked in now, the escaped names stay literal
 # for grub to expand at config-generation time.
 DROPIN_CONTENT="$(cat <<EOF
-# Managed by the nvidia-tuned Skyhook package (configure_bootloader.sh). Do not edit.
+# ${DROPIN_MARKER}. Do not edit.
 #
 # Sources the cmdline tuned resolved from the active profile's [bootloader] stanza.
 # Without this, a profile's [bootloader] settings never reach the kernel on Ubuntu.
@@ -68,14 +83,19 @@ fi
 EOF
 )"
 
-# Identifies a drop-in this package owns. The eks and aks services write their own
-# grub.d file from inside the tuned profile; scoping removal to our marker keeps this
-# step from deleting theirs when it stands down on a node running one of them.
-DROPIN_MARKER="Managed by the nvidia-tuned Skyhook package (configure_bootloader.sh)"
-
 # Returns 0 when the drop-in exists and this package wrote it.
 dropin_is_ours() {
     [[ -f "${TUNED_GRUB_DROPIN}" ]] && grep -qF "${DROPIN_MARKER}" "${TUNED_GRUB_DROPIN}"
+}
+
+# Returns 0 unless CONFIGURE_BOOTLOADER switches the step off.
+bootloader_requested() {
+    local setting
+    setting="$(printf '%s' "${CONFIGURE_BOOTLOADER:-true}" | tr '[:upper:]' '[:lower:]')"
+    case "${setting}" in
+        false | 0 | no | off) return 1 ;;
+        *) return 0 ;;
+    esac
 }
 
 # Returns 0 when the configured service opts in.
@@ -89,20 +109,56 @@ bootloader_enabled() {
     [[ -f "${PROFILES_DIR}/service/${service}/bootloader.enabled" ]]
 }
 
-# Mirrors the fallback chain in kdump's update_grub_config().
+# Returns 0 on a distribution whose grub-mkconfig sources /etc/default/grub.d/*.cfg.
+#
+# Checks ID and ID_LIKE so Debian derivatives that do carry the patch (Pop, Mint, and the
+# vendor Ubuntu rebuilds these nodes run) are recognised without an explicit allowlist.
+bootloader_os_supported() {
+    local ids
+
+    [[ -r "${OS_RELEASE}" ]] || return 1
+    # set +u inside the subshell: os-release is a fragment, not a script of ours.
+    ids="$(
+        set +u
+        # shellcheck source=/dev/null
+        . "${OS_RELEASE}" 2>/dev/null
+        printf '%s %s' "${ID:-}" "${ID_LIKE:-}"
+    )"
+
+    case " ${ids} " in
+        *" debian "* | *" ubuntu "*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+# Reports the distribution for error messages.
+os_pretty_name() {
+    (
+        set +u
+        # shellcheck source=/dev/null
+        . "${OS_RELEASE}" 2>/dev/null
+        printf '%s' "${PRETTY_NAME:-${ID:-unknown}}"
+    )
+}
+
+# Debian-family only, so update-grub is the mechanism. No grub2-mkconfig fallback: it
+# would regenerate a RHEL-family grub.cfg that ignores the drop-in, turning an
+# unsupported platform into a silent no-op instead of a visible failure.
 regenerate_grub() {
-    if command -v update-grub >/dev/null 2>&1; then
-        update-grub
-    elif command -v grub2-mkconfig >/dev/null 2>&1; then
-        if [[ -d /boot/grub2 ]]; then
-            grub2-mkconfig -o /boot/grub2/grub.cfg
-        else
-            grub2-mkconfig -o /boot/efi/EFI/redhat/grub.cfg
-        fi
-    else
-        echo "ERROR: neither update-grub nor grub2-mkconfig is available"
+    if [[ -n "${SKIP_SYSTEM_OPERATIONS:-}" ]]; then
+        echo "SKIP_SYSTEM_OPERATIONS set: not regenerating the bootloader config"
+        return 0
+    fi
+
+    if ! command -v update-grub >/dev/null 2>&1; then
+        echo "ERROR: update-grub is not available, so the drop-in cannot be applied."
+        echo "  This step supports GRUB on Debian-family distributions. A node booting"
+        echo "  through something else (systemd-boot, a UKI) needs CONFIGURE_BOOTLOADER=false"
+        echo "  and its kernel arguments set by whatever owns them."
         return 1
     fi
+
+    update-grub
 }
 
 # Drop a drop-in this package previously wrote. Called when the service gate stops
@@ -126,11 +182,47 @@ remove_dropin() {
     echo "Removed ${TUNED_GRUB_DROPIN}; a reboot is required to drop the profile cmdline"
 }
 
+# The only place an operator will look, so name the cause and both ways forward.
+fail_unsupported_os() {
+    cat <<EOF
+ERROR: This node's distribution does not support the bootloader mechanism this step uses.
+
+  Detected: $(os_pretty_name)
+
+  The step writes ${TUNED_GRUB_DROPIN} and relies on grub-mkconfig sourcing
+  /etc/default/grub.d/*.cfg, which is a Debian/Ubuntu patch. RHEL-family grub2-mkconfig
+  reads /etc/default/grub and /etc/grub.d/ and ignores that directory, so the drop-in
+  would be written, GRUB would regenerate without error, and none of the profile's kernel
+  arguments would reach the booted kernel.
+
+  This fails rather than passing quietly because the alternative is a node that reports
+  success while running none of the tuning it was selected for.
+
+  Either:
+    - use a service that does not carry [bootloader] tuning (bcm re-roots the same
+      accelerators onto a bootloader-free profile chain), or
+    - set CONFIGURE_BOOTLOADER=false in the package env on the custom resource to skip
+      this step and its checks, and set the kernel arguments by another route.
+EOF
+    exit 1
+}
+
 main() {
+    if ! bootloader_requested; then
+        echo "Bootloader step switched off via CONFIGURE_BOOTLOADER; nothing to configure"
+        return 0
+    fi
+
     if ! bootloader_enabled; then
         echo "Bootloader drop-in not enabled for this service; nothing to configure"
         remove_dropin
         return 0
+    fi
+
+    # After the service gate, so an unsupported distribution running a service that never
+    # wanted a drop-in is not failed for it.
+    if ! bootloader_os_supported; then
+        fail_unsupported_os
     fi
 
     # Not fatal. The drop-in guards on the file, so it starts contributing as soon as

--- a/nvidia-tuned/skyhook_dir/configure_bootloader.sh
+++ b/nvidia-tuned/skyhook_dir/configure_bootloader.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Makes the active profile's [bootloader] cmdline reach the booted kernel on Ubuntu.
+#
+# tuned writes the resolved [bootloader] stanza to /etc/tuned/bootcmdline as
+# TUNED_BOOT_CMDLINE, then rewrites /etc/default/grub itself. Ubuntu assembles
+# GRUB_CMDLINE_LINUX_DEFAULT from /etc/default/grub.d/ instead, so on Ubuntu that rewrite
+# is ignored and the profile's cmdline silently never applies. This step writes a
+# /etc/default/grub.d/ drop-in that sources tuned's file, then regenerates grub.
+#
+# Gated on ${SKYHOOK_DIR}/profiles/service/${service}/bootloader.enabled, so services
+# without the marker are a no-op. The marker is service-wide rather than per-accelerator:
+# every accelerator reached through such a service wants its cmdline on the host.
+#
+# Runs after the config step that applies the profile, because /etc/tuned/bootcmdline
+# only exists once tuned has activated it.
+#
+# Lands on the kernel command line, so it needs `interrupt: {type: reboot}`.
+
+set -euo pipefail
+
+CONFIGMAP_DIR="${SKYHOOK_DIR}/configmaps"
+PROFILES_DIR="${SKYHOOK_DIR}/profiles"
+
+# Overridable so tests can point at a stub.
+TUNED_GRUB_DROPIN="${TUNED_GRUB_DROPIN:-/etc/default/grub.d/99-nvidia-tuned-cmdline.cfg}"
+TUNED_BOOTCMDLINE="${TUNED_BOOTCMDLINE:-/etc/tuned/bootcmdline}"
+
+# 99_ sorts after every numbered producer, so this assignment is evaluated last and its
+# arguments win where a token is set twice.
+#
+# Appends to GRUB_CMDLINE_LINUX_DEFAULT rather than replacing it, which is where this
+# differs from the older in-profile script the eks and aks services use. Replacing it
+# drops whatever the platform put there, which on a bare-metal host includes the serial
+# console arguments an operator needs to reach a node that fails to come up.
+#
+# Deliberately a different filename from that script's 99_tuned.cfg: the two must be able
+# to coexist on a node that has switched services, and this step must never remove a file
+# it did not write.
+#
+# Unquoted heredoc: ${TUNED_BOOTCMDLINE} is baked in now, the escaped names stay literal
+# for grub to expand at config-generation time.
+DROPIN_CONTENT="$(cat <<EOF
+# Managed by the nvidia-tuned Skyhook package (configure_bootloader.sh). Do not edit.
+#
+# Sources the cmdline tuned resolved from the active profile's [bootloader] stanza.
+# Without this, a profile's [bootloader] settings never reach the kernel on Ubuntu.
+if [ -f ${TUNED_BOOTCMDLINE} ]; then
+    . ${TUNED_BOOTCMDLINE}
+    GRUB_CMDLINE_LINUX_DEFAULT="\${GRUB_CMDLINE_LINUX_DEFAULT} \${TUNED_BOOT_CMDLINE}"
+fi
+EOF
+)"
+
+# Identifies a drop-in this package owns. The eks and aks services write their own
+# grub.d file from inside the tuned profile; scoping removal to our marker keeps this
+# step from deleting theirs when it stands down on a node running one of them.
+DROPIN_MARKER="Managed by the nvidia-tuned Skyhook package (configure_bootloader.sh)"
+
+# Returns 0 when the drop-in exists and this package wrote it.
+dropin_is_ours() {
+    [[ -f "${TUNED_GRUB_DROPIN}" ]] && grep -qF "${DROPIN_MARKER}" "${TUNED_GRUB_DROPIN}"
+}
+
+# Returns 0 when the configured service opts in.
+bootloader_enabled() {
+    local service
+
+    [[ -f "${CONFIGMAP_DIR}/service" ]] || return 1
+    service="$(xargs < "${CONFIGMAP_DIR}/service")"
+    [[ -n "${service}" ]] || return 1
+
+    [[ -f "${PROFILES_DIR}/service/${service}/bootloader.enabled" ]]
+}
+
+# Mirrors the fallback chain in kdump's update_grub_config().
+regenerate_grub() {
+    if command -v update-grub >/dev/null 2>&1; then
+        update-grub
+    elif command -v grub2-mkconfig >/dev/null 2>&1; then
+        if [[ -d /boot/grub2 ]]; then
+            grub2-mkconfig -o /boot/grub2/grub.cfg
+        else
+            grub2-mkconfig -o /boot/efi/EFI/redhat/grub.cfg
+        fi
+    else
+        echo "ERROR: neither update-grub nor grub2-mkconfig is available"
+        return 1
+    fi
+}
+
+# Drop a drop-in this package previously wrote. Called when the service gate stops
+# matching, so a custom resource switched from rke2 to a no-reboot service does not keep
+# contributing the old cmdline on every future boot with no package owning it.
+remove_dropin() {
+    dropin_is_ours || return 0
+
+    local backup
+    backup="$(mktemp)"
+    cp "${TUNED_GRUB_DROPIN}" "${backup}"
+    rm -f "${TUNED_GRUB_DROPIN}"
+
+    if ! regenerate_grub; then
+        mv "${backup}" "${TUNED_GRUB_DROPIN}"
+        echo "ERROR: could not regenerate the bootloader config; restored ${TUNED_GRUB_DROPIN}"
+        exit 1
+    fi
+
+    rm -f "${backup}"
+    echo "Removed ${TUNED_GRUB_DROPIN}; a reboot is required to drop the profile cmdline"
+}
+
+main() {
+    if ! bootloader_enabled; then
+        echo "Bootloader drop-in not enabled for this service; nothing to configure"
+        remove_dropin
+        return 0
+    fi
+
+    # Not fatal. The drop-in guards on the file, so it starts contributing as soon as
+    # tuned writes one, and a profile chain carrying no [bootloader] stanza legitimately
+    # produces no bootcmdline at all. configure_bootloader_check.sh reports the mismatch.
+    if [[ ! -f "${TUNED_BOOTCMDLINE}" ]]; then
+        echo "WARNING: ${TUNED_BOOTCMDLINE} does not exist; the active profile chain resolved no [bootloader] settings"
+    fi
+
+    # Deliberately no "content already current, skipping" short-circuit. The drop-in is
+    # static but the file it sources is not: changing intent rewrites
+    # /etc/tuned/bootcmdline while leaving this file byte-identical, and grub only picks
+    # the new value up when it is regenerated. Skipping on unchanged content would leave
+    # the node booting the previous intent's cmdline.
+    local backup=""
+    if [[ -f "${TUNED_GRUB_DROPIN}" ]]; then
+        backup="$(mktemp)"
+        cp "${TUNED_GRUB_DROPIN}" "${backup}"
+    fi
+
+    mkdir -p "$(dirname "${TUNED_GRUB_DROPIN}")"
+    printf '%s\n' "${DROPIN_CONTENT}" > "${TUNED_GRUB_DROPIN}"
+
+    if ! regenerate_grub; then
+        if [[ -n "${backup}" ]]; then
+            mv "${backup}" "${TUNED_GRUB_DROPIN}"
+            echo "ERROR: could not regenerate the bootloader config; restored the previous ${TUNED_GRUB_DROPIN}"
+        else
+            rm -f "${TUNED_GRUB_DROPIN}"
+            echo "ERROR: could not regenerate the bootloader config; removed ${TUNED_GRUB_DROPIN}"
+        fi
+        exit 1
+    fi
+
+    if [[ -n "${backup}" ]]; then
+        rm -f "${backup}"
+    fi
+
+    echo "Wrote ${TUNED_GRUB_DROPIN}; a reboot is required for the profile cmdline to take effect"
+}
+
+main "$@"

--- a/nvidia-tuned/skyhook_dir/configure_bootloader_check.sh
+++ b/nvidia-tuned/skyhook_dir/configure_bootloader_check.sh
@@ -32,6 +32,35 @@ PROFILES_DIR="${SKYHOOK_DIR}/profiles"
 
 TUNED_GRUB_DROPIN="${TUNED_GRUB_DROPIN:-/etc/default/grub.d/99-nvidia-tuned-cmdline.cfg}"
 TUNED_BOOTCMDLINE="${TUNED_BOOTCMDLINE:-/etc/tuned/bootcmdline}"
+OS_RELEASE="${OS_RELEASE:-/etc/os-release}"
+
+# Mirrors bootloader_requested() in configure_bootloader.sh.
+bootloader_requested() {
+    local setting
+    setting="$(printf '%s' "${CONFIGURE_BOOTLOADER:-true}" | tr '[:upper:]' '[:lower:]')"
+    case "${setting}" in
+        false | 0 | no | off) return 1 ;;
+        *) return 0 ;;
+    esac
+}
+
+# Mirrors bootloader_os_supported() in configure_bootloader.sh.
+bootloader_os_supported() {
+    local ids
+
+    [[ -r "${OS_RELEASE}" ]] || return 1
+    ids="$(
+        set +u
+        # shellcheck source=/dev/null
+        . "${OS_RELEASE}" 2>/dev/null
+        printf '%s %s' "${ID:-}" "${ID_LIKE:-}"
+    )"
+
+    case " ${ids} " in
+        *" debian "* | *" ubuntu "*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
 
 # Mirrors bootloader_enabled() in configure_bootloader.sh.
 bootloader_enabled() {
@@ -69,9 +98,22 @@ generated_cmdline() {
 main() {
     local expected generated token tokens=() missing=()
 
+    if ! bootloader_requested; then
+        echo "Bootloader step switched off via CONFIGURE_BOOTLOADER; nothing to verify"
+        return 0
+    fi
+
     if ! bootloader_enabled; then
         echo "Bootloader drop-in not enabled for this service; nothing to verify"
         return 0
+    fi
+
+    # Reachable only if configure_bootloader.sh was bypassed; it fails on this platform.
+    # Passing here would certify a drop-in that grub never reads.
+    if ! bootloader_os_supported; then
+        echo "ERROR: this distribution's grub-mkconfig does not source /etc/default/grub.d/*.cfg,"
+        echo "  so the drop-in cannot take effect. Set CONFIGURE_BOOTLOADER=false to skip this step."
+        exit 1
     fi
 
     if [[ ! -f "${TUNED_GRUB_DROPIN}" ]]; then

--- a/nvidia-tuned/skyhook_dir/configure_bootloader_check.sh
+++ b/nvidia-tuned/skyhook_dir/configure_bootloader_check.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Verifies configure_bootloader.sh left a drop-in that will carry the profile's cmdline
+# into the next boot.
+#
+# Runs before the reboot, so the running kernel still has the old command line; passing
+# only means the drop-in resolves correctly. post_interrupt_bootloader_check.sh asserts
+# it took effect.
+#
+# A non-zero exit is the signal, so no `set -e`.
+
+set -uo pipefail
+
+CONFIGMAP_DIR="${SKYHOOK_DIR}/configmaps"
+PROFILES_DIR="${SKYHOOK_DIR}/profiles"
+
+TUNED_GRUB_DROPIN="${TUNED_GRUB_DROPIN:-/etc/default/grub.d/99-nvidia-tuned-cmdline.cfg}"
+TUNED_BOOTCMDLINE="${TUNED_BOOTCMDLINE:-/etc/tuned/bootcmdline}"
+
+# Mirrors bootloader_enabled() in configure_bootloader.sh.
+bootloader_enabled() {
+    local service
+
+    [[ -f "${CONFIGMAP_DIR}/service" ]] || return 1
+    service="$(xargs < "${CONFIGMAP_DIR}/service")"
+    [[ -n "${service}" ]] || return 1
+
+    [[ -f "${PROFILES_DIR}/service/${service}/bootloader.enabled" ]]
+}
+
+# The cmdline tuned resolved from the active profile chain, or empty.
+tuned_cmdline() {
+    # set +u inside the subshell: these files are grub/tuned fragments that reference
+    # names this script does not define.
+    (
+        set +u
+        # shellcheck source=/dev/null
+        . "${TUNED_BOOTCMDLINE}" 2>/dev/null
+        printf '%s' "${TUNED_BOOT_CMDLINE:-}"
+    )
+}
+
+# What grub would end up with after evaluating the drop-in, or empty.
+generated_cmdline() {
+    (
+        set +u
+        # shellcheck source=/dev/null
+        . "${TUNED_GRUB_DROPIN}" 2>/dev/null
+        printf '%s' "${GRUB_CMDLINE_LINUX_DEFAULT:-}"
+    )
+}
+
+main() {
+    local expected generated token tokens=() missing=()
+
+    if ! bootloader_enabled; then
+        echo "Bootloader drop-in not enabled for this service; nothing to verify"
+        return 0
+    fi
+
+    if [[ ! -f "${TUNED_GRUB_DROPIN}" ]]; then
+        echo "ERROR: the bootloader step was requested but no drop-in exists at ${TUNED_GRUB_DROPIN}"
+        exit 1
+    fi
+
+    if [[ ! -f "${TUNED_BOOTCMDLINE}" ]]; then
+        echo "ERROR: ${TUNED_BOOTCMDLINE} does not exist, so the active profile chain resolved no [bootloader] settings."
+        echo "  This service exists to carry those settings onto the host, so an empty cmdline means it is doing nothing."
+        echo "  Check that the accelerator's profile chain was not re-rooted onto a bootloader-free base."
+        exit 1
+    fi
+
+    expected="$(tuned_cmdline)"
+    if [[ -z "${expected}" ]]; then
+        echo "ERROR: ${TUNED_BOOTCMDLINE} sets no TUNED_BOOT_CMDLINE, so there is nothing for the drop-in to contribute"
+        exit 1
+    fi
+
+    # Evaluate the drop-in the way grub will rather than pattern-matching its text: that
+    # catches a drop-in whose guard never fires or whose assignment is commented out,
+    # which reads as present but contributes nothing.
+    generated="$(generated_cmdline)"
+
+    read -ra tokens <<< "${expected}"
+    if (( ${#tokens[@]} == 0 )); then
+        echo "ERROR: TUNED_BOOT_CMDLINE in ${TUNED_BOOTCMDLINE} holds no arguments"
+        exit 1
+    fi
+
+    for token in "${tokens[@]}"; do
+        case " ${generated} " in
+            *" ${token} "*) ;;
+            *) missing+=("${token}") ;;
+        esac
+    done
+
+    if (( ${#missing[@]} > 0 )); then
+        echo "ERROR: ${TUNED_GRUB_DROPIN} does not resolve to the profile's cmdline."
+        echo "  Expected to find: ${missing[*]}"
+        echo "  Drop-in resolves to: ${generated}"
+        exit 1
+    fi
+
+    echo "Verified ${TUNED_GRUB_DROPIN} resolves to the profile cmdline; pending reboot"
+    echo "  ${expected}"
+}
+
+main "$@"

--- a/nvidia-tuned/skyhook_dir/post_interrupt_bootloader_check.sh
+++ b/nvidia-tuned/skyhook_dir/post_interrupt_bootloader_check.sh
@@ -33,6 +33,35 @@ PROFILES_DIR="${SKYHOOK_DIR}/profiles"
 PROC_CMDLINE="${PROC_CMDLINE:-/proc/cmdline}"
 TUNED_GRUB_DROPIN="${TUNED_GRUB_DROPIN:-/etc/default/grub.d/99-nvidia-tuned-cmdline.cfg}"
 TUNED_BOOTCMDLINE="${TUNED_BOOTCMDLINE:-/etc/tuned/bootcmdline}"
+OS_RELEASE="${OS_RELEASE:-/etc/os-release}"
+
+# Mirrors bootloader_requested() in configure_bootloader.sh.
+bootloader_requested() {
+    local setting
+    setting="$(printf '%s' "${CONFIGURE_BOOTLOADER:-true}" | tr '[:upper:]' '[:lower:]')"
+    case "${setting}" in
+        false | 0 | no | off) return 1 ;;
+        *) return 0 ;;
+    esac
+}
+
+# Mirrors bootloader_os_supported() in configure_bootloader.sh.
+bootloader_os_supported() {
+    local ids
+
+    [[ -r "${OS_RELEASE}" ]] || return 1
+    ids="$(
+        set +u
+        # shellcheck source=/dev/null
+        . "${OS_RELEASE}" 2>/dev/null
+        printf '%s %s' "${ID:-}" "${ID_LIKE:-}"
+    )"
+
+    case " ${ids} " in
+        *" debian "* | *" ubuntu "*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
 
 # Mirrors bootloader_enabled() in configure_bootloader.sh.
 bootloader_enabled() {
@@ -82,9 +111,19 @@ EOF
 main() {
     local expected booted token tokens=() missing=()
 
+    if ! bootloader_requested; then
+        echo "Bootloader step switched off via CONFIGURE_BOOTLOADER; nothing to verify"
+        return 0
+    fi
+
     if ! bootloader_enabled; then
         echo "Bootloader drop-in not enabled for this service; nothing to verify"
         return 0
+    fi
+
+    if ! bootloader_os_supported; then
+        echo "ERROR: this distribution cannot apply the drop-in; CONFIGURE_BOOTLOADER=false skips it"
+        exit 1
     fi
 
     if [[ ! -f "${TUNED_BOOTCMDLINE}" ]]; then

--- a/nvidia-tuned/skyhook_dir/post_interrupt_bootloader_check.sh
+++ b/nvidia-tuned/skyhook_dir/post_interrupt_bootloader_check.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Verifies the profile's [bootloader] cmdline is live after the reboot interrupt.
+#
+# This is the check that makes the reboot meaningful: everything before it only proves a
+# drop-in exists, and the failure it catches -- grub silently not picking the drop-in up
+# -- is invisible from the config stage. The tuning the node was labelled for is simply
+# absent until someone reads /proc/cmdline.
+#
+# A non-zero exit is the signal, so no `set -e`.
+
+set -uo pipefail
+
+CONFIGMAP_DIR="${SKYHOOK_DIR}/configmaps"
+PROFILES_DIR="${SKYHOOK_DIR}/profiles"
+
+PROC_CMDLINE="${PROC_CMDLINE:-/proc/cmdline}"
+TUNED_GRUB_DROPIN="${TUNED_GRUB_DROPIN:-/etc/default/grub.d/99-nvidia-tuned-cmdline.cfg}"
+TUNED_BOOTCMDLINE="${TUNED_BOOTCMDLINE:-/etc/tuned/bootcmdline}"
+
+# Mirrors bootloader_enabled() in configure_bootloader.sh.
+bootloader_enabled() {
+    local service
+
+    [[ -f "${CONFIGMAP_DIR}/service" ]] || return 1
+    service="$(xargs < "${CONFIGMAP_DIR}/service")"
+    [[ -n "${service}" ]] || return 1
+
+    [[ -f "${PROFILES_DIR}/service/${service}/bootloader.enabled" ]]
+}
+
+# The cmdline tuned resolved from the active profile chain, or empty.
+tuned_cmdline() {
+    # set +u inside the subshell: tuned's fragment references names this script does not
+    # define.
+    (
+        set +u
+        # shellcheck source=/dev/null
+        . "${TUNED_BOOTCMDLINE}" 2>/dev/null
+        printf '%s' "${TUNED_BOOT_CMDLINE:-}"
+    )
+}
+
+# The only place an operator will look, so name the cause and where to look next.
+fail_not_applied() {
+    cat <<EOF
+ERROR: The tuned profile's kernel command line did not take effect on this node.
+
+  ${1}
+
+  Impact: the node is running without the tuning it was selected for. Depending on the
+  profile that can mean no hugepages backing GPU workloads, NUMA balancing left on, or
+  no serial console on a host that fails to come up.
+
+  Where to look:
+    - cat ${PROC_CMDLINE}
+    - cat ${TUNED_BOOTCMDLINE}
+    - cat ${TUNED_GRUB_DROPIN}
+    - ls /etc/default/grub.d/   (a file sorting later can overwrite
+                                 GRUB_CMDLINE_LINUX_DEFAULT wholesale)
+    - grep GRUB_DEFAULT /etc/default/grub   (the node may have booted another entry)
+EOF
+    exit 1
+}
+
+main() {
+    local expected booted token tokens=() missing=()
+
+    if ! bootloader_enabled; then
+        echo "Bootloader drop-in not enabled for this service; nothing to verify"
+        return 0
+    fi
+
+    if [[ ! -f "${TUNED_BOOTCMDLINE}" ]]; then
+        fail_not_applied "${TUNED_BOOTCMDLINE} does not exist, so no profile cmdline was ever resolved."
+    fi
+
+    expected="$(tuned_cmdline)"
+    read -ra tokens <<< "${expected}"
+    if (( ${#tokens[@]} == 0 )); then
+        fail_not_applied "${TUNED_BOOTCMDLINE} sets no TUNED_BOOT_CMDLINE arguments."
+    fi
+
+    booted="$(tr -s '[:space:]' ' ' < "${PROC_CMDLINE}")"
+
+    for token in "${tokens[@]}"; do
+        case " ${booted} " in
+            *" ${token} "*) ;;
+            *) missing+=("${token}") ;;
+        esac
+    done
+
+    if (( ${#missing[@]} > 0 )); then
+        fail_not_applied "The booted kernel command line is missing: ${missing[*]}"
+    fi
+
+    echo "Verified the profile cmdline is live after reboot"
+    echo "  ${expected}"
+}
+
+main "$@"

--- a/nvidia-tuned/skyhook_dir/uninstall_bootloader.sh
+++ b/nvidia-tuned/skyhook_dir/uninstall_bootloader.sh
@@ -45,20 +45,22 @@ dropin_is_ours() {
     [[ -f "${TUNED_GRUB_DROPIN}" ]] && grep -qF "${DROPIN_MARKER}" "${TUNED_GRUB_DROPIN}"
 }
 
-# Mirrors the fallback chain in kdump's update_grub_config().
+# Mirrors regenerate_grub() in configure_bootloader.sh. update-grub only: the drop-in is
+# written on Debian-family nodes exclusively, so that is the only place there is one to
+# remove, and a grub2-mkconfig fallback here would regenerate a config that never
+# referenced it.
 regenerate_grub() {
-    if command -v update-grub >/dev/null 2>&1; then
-        update-grub
-    elif command -v grub2-mkconfig >/dev/null 2>&1; then
-        if [[ -d /boot/grub2 ]]; then
-            grub2-mkconfig -o /boot/grub2/grub.cfg
-        else
-            grub2-mkconfig -o /boot/efi/EFI/redhat/grub.cfg
-        fi
-    else
-        echo "ERROR: neither update-grub nor grub2-mkconfig is available"
+    if [[ -n "${SKIP_SYSTEM_OPERATIONS:-}" ]]; then
+        echo "SKIP_SYSTEM_OPERATIONS set: not regenerating the bootloader config"
+        return 0
+    fi
+
+    if ! command -v update-grub >/dev/null 2>&1; then
+        echo "ERROR: update-grub is not available, so the removal cannot be applied to grub.cfg"
         return 1
     fi
+
+    update-grub
 }
 
 main() {

--- a/nvidia-tuned/skyhook_dir/uninstall_bootloader.sh
+++ b/nvidia-tuned/skyhook_dir/uninstall_bootloader.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Removes the grub.d drop-in written by configure_bootloader.sh.
+#
+# Runs unconditionally rather than self-gating on the service marker: uninstall must also
+# clean up after a custom resource whose configmaps have since changed, so it keys on
+# what is on the host. Removing a drop-in that was never written is a no-op.
+#
+# The drop-in only sources tuned's own file, so leaving it behind would keep applying the
+# uninstalled package's cmdline on every future boot for as long as /etc/tuned/bootcmdline
+# survives, with no package owning it. Removing it is the correct as-if-never-installed
+# state.
+#
+# Scoped to the drop-in this package wrote, identified by its marker line. The eks and
+# aks services write their own grub.d file from inside the tuned profile; removing that
+# one is not this step's business.
+#
+# Takes effect on the next boot, like the change it reverts.
+
+set -euo pipefail
+
+TUNED_GRUB_DROPIN="${TUNED_GRUB_DROPIN:-/etc/default/grub.d/99-nvidia-tuned-cmdline.cfg}"
+
+# Mirrors DROPIN_MARKER in configure_bootloader.sh.
+DROPIN_MARKER="Managed by the nvidia-tuned Skyhook package (configure_bootloader.sh)"
+
+# Returns 0 when the drop-in exists and this package wrote it.
+dropin_is_ours() {
+    [[ -f "${TUNED_GRUB_DROPIN}" ]] && grep -qF "${DROPIN_MARKER}" "${TUNED_GRUB_DROPIN}"
+}
+
+# Mirrors the fallback chain in kdump's update_grub_config().
+regenerate_grub() {
+    if command -v update-grub >/dev/null 2>&1; then
+        update-grub
+    elif command -v grub2-mkconfig >/dev/null 2>&1; then
+        if [[ -d /boot/grub2 ]]; then
+            grub2-mkconfig -o /boot/grub2/grub.cfg
+        else
+            grub2-mkconfig -o /boot/efi/EFI/redhat/grub.cfg
+        fi
+    else
+        echo "ERROR: neither update-grub nor grub2-mkconfig is available"
+        return 1
+    fi
+}
+
+main() {
+    if ! dropin_is_ours; then
+        echo "No nvidia-tuned bootloader drop-in at ${TUNED_GRUB_DROPIN}; nothing to remove"
+        return 0
+    fi
+
+    # Back the drop-in up before removing it. If grub regeneration fails the generated
+    # config still carries the profile cmdline, and leaving the source file deleted would
+    # make the next uninstall report success against a node that still boots with it.
+    local backup
+    backup="$(mktemp)"
+    cp "${TUNED_GRUB_DROPIN}" "${backup}"
+    rm -f "${TUNED_GRUB_DROPIN}"
+
+    if ! regenerate_grub; then
+        mv "${backup}" "${TUNED_GRUB_DROPIN}"
+        echo "ERROR: could not regenerate the bootloader config; restored ${TUNED_GRUB_DROPIN}"
+        return 1
+    fi
+
+    rm -f "${backup}"
+    echo "Removed ${TUNED_GRUB_DROPIN}; a reboot is required to drop the profile cmdline"
+}
+
+main "$@"

--- a/nvidia-tuned/skyhook_dir/uninstall_bootloader_check.sh
+++ b/nvidia-tuned/skyhook_dir/uninstall_bootloader_check.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Verifies uninstall_bootloader.sh removed the grub.d drop-in.
+#
+# A non-zero exit is the signal here, so this script does not use `set -e`; expected
+# failures are handled explicitly.
+#
+# Asserts the drop-in is gone rather than that the cmdline is gone from the running
+# kernel: the change only takes effect at the next boot, so live state still shows
+# whatever the node booted with.
+
+set -uo pipefail
+
+TUNED_GRUB_DROPIN="${TUNED_GRUB_DROPIN:-/etc/default/grub.d/99-nvidia-tuned-cmdline.cfg}"
+
+DROPIN_MARKER="Managed by the nvidia-tuned Skyhook package (configure_bootloader.sh)"
+
+main() {
+    # Keys on the marker, not mere existence: a file another service owns at this path is
+    # not a failed uninstall.
+    if [[ -f "${TUNED_GRUB_DROPIN}" ]] && grep -qF "${DROPIN_MARKER}" "${TUNED_GRUB_DROPIN}"; then
+        echo "ERROR: ${TUNED_GRUB_DROPIN} still present"
+        exit 1
+    fi
+
+    echo "Verified the bootloader drop-in is removed"
+}
+
+main "$@"

--- a/tests/integration/nvidia_tuned/test_prepare_nvidia_profiles.py
+++ b/tests/integration/nvidia_tuned/test_prepare_nvidia_profiles.py
@@ -1055,16 +1055,66 @@ def test_prepare_nvidia_profiles_rke2_marker_not_deployed(base_image):
         runner.cleanup()
 
 
+
+# --- configure_bootloader.sh and friends --------------------------------------------
+#
+# The grub.d drop-in only works on Debian-family distributions: sourcing
+# /etc/default/grub.d/*.cfg is a Debian/Ubuntu patch to grub-mkconfig, and RHEL-family
+# grub2-mkconfig ignores that directory. The step fails loudly there rather than writing
+# a file nothing reads, so the matrix's rockylinux:9 entry exercises the rejection path
+# while the Debian-family entries exercise the working one.
+
+# Cleared so the stub update-grub actually runs. run_script_in_container sets
+# SKIP_SYSTEM_OPERATIONS=true for the whole suite, and the step honours it by not
+# touching the bootloader at all, which is the behavior test_..._skips_system_operations
+# covers separately.
+RUN_ENV = {**STUB_ENV, "SKIP_SYSTEM_OPERATIONS": ""}
+
+STUB_OS_RELEASE = "/tmp/os-release-stub"
+
+# A RHEL-family os-release, for exercising the rejection path on Debian-family images.
+RHEL_OS_RELEASE = 'ID="rocky"\\nID_LIKE="rhel centos fedora"\\nPRETTY_NAME="Rocky Linux 9.4"\\n'
+
+
+def _is_debian_family(base_image: str) -> bool:
+    return "ubuntu" in base_image or "debian" in base_image
+
+
+def _skip_non_debian(base_image):
+    """The drop-in mechanism is Debian-family only; the step fails elsewhere by design."""
+    if not _is_debian_family(base_image):
+        pytest.skip(f"grub.d drop-ins are Debian-family only; skipping for {base_image}")
+
+
+def _write_os_release(runner: DockerTestRunner, path: str, contents: str):
+    runner.container.exec_run(["bash", "-c", f"printf '{contents}' > {path}"], workdir="/")
+
+
+def _install_failing_grub_stub(runner: DockerTestRunner):
+    """Stub update-grub as failing, to exercise the rollback paths."""
+    runner.container.exec_run(
+        ["bash", "-c", "printf '#!/bin/sh\\nexit 3\\n' > /usr/local/bin/update-grub "
+                       "&& chmod +x /usr/local/bin/update-grub"],
+        workdir="/",
+    )
+
+
+def _rke2_container(runner: DockerTestRunner, intent="performance", accelerator="gb200"):
+    configmaps = {"accelerator": accelerator, "intent": intent, "service": "rke2"}
+    create_container_for_testing(runner, configmaps)
+    return configmaps
+
+
 def test_configure_bootloader_writes_dropin(base_image):
-    """configure_bootloader.sh writes a drop-in that resolves to the profile cmdline."""
+    """The drop-in is written, grub is regenerated, and it resolves to the profile cmdline."""
+    _skip_non_debian(base_image)
     runner = DockerTestRunner(package="nvidia-tuned", base_image=base_image)
     try:
-        configmaps = {"accelerator": "gb200", "intent": "performance", "service": "rke2"}
-        create_container_for_testing(runner, configmaps)
+        _rke2_container(runner)
         _install_grub_stub(runner)
         _write_bootcmdline(runner, STUB_BOOTCMDLINE, SAMPLE_CMDLINE)
 
-        result = _run_with_env(runner, "configure_bootloader.sh", STUB_ENV)
+        result = _run_with_env(runner, "configure_bootloader.sh", RUN_ENV)
         assert_exit_code(result, 0)
         assert runner.file_exists(STUB_DROPIN), f"drop-in was not written to {STUB_DROPIN}"
         assert runner.file_exists("/tmp/update-grub.ran"), "grub was not regenerated"
@@ -1077,9 +1127,169 @@ def test_configure_bootloader_writes_dropin(base_image):
         for token in SAMPLE_CMDLINE.split():
             assert token in resolved, f"{token} missing from resolved cmdline: {resolved!r}"
 
-        # The check step agrees.
-        check = _run_with_env(runner, "configure_bootloader_check.sh", STUB_ENV)
+        check = _run_with_env(runner, "configure_bootloader_check.sh", RUN_ENV)
         assert_exit_code(check, 0)
+    finally:
+        runner.cleanup()
+
+
+def test_configure_bootloader_refreshes_on_cmdline_change(base_image):
+    """A changed cmdline regenerates grub even though the drop-in is byte-identical.
+
+    The drop-in only sources /etc/tuned/bootcmdline, so changing intent rewrites that
+    file while leaving the drop-in unchanged. Short-circuiting on unchanged drop-in
+    content would leave the node booting the previous intent's cmdline.
+    """
+    _skip_non_debian(base_image)
+    runner = DockerTestRunner(package="nvidia-tuned", base_image=base_image)
+    try:
+        _rke2_container(runner)
+        _install_grub_stub(runner)
+        _write_bootcmdline(runner, STUB_BOOTCMDLINE, SAMPLE_CMDLINE)
+        assert_exit_code(_run_with_env(runner, "configure_bootloader.sh", RUN_ENV), 0)
+        before = runner.get_file_contents(STUB_DROPIN)
+
+        # New cmdline, and clear the regeneration marker so the rerun is what we observe.
+        runner.container.exec_run(["bash", "-c", "rm -f /tmp/update-grub.ran"], workdir="/")
+        changed = "iommu.passthrough=1 numa_balancing=disable hugepagesz=1G hugepages=2"
+        _write_bootcmdline(runner, STUB_BOOTCMDLINE, changed)
+
+        result = _run_with_env(runner, "configure_bootloader.sh", RUN_ENV)
+        assert_exit_code(result, 0)
+        assert runner.file_exists("/tmp/update-grub.ran"), \
+            "grub must be regenerated when the sourced cmdline changes"
+        assert runner.get_file_contents(STUB_DROPIN) == before, \
+            "the drop-in itself should not change; only the file it sources does"
+
+        resolved = runner.container.exec_run(
+            ["bash", "-c", f'. {STUB_DROPIN}; printf "%s" "$GRUB_CMDLINE_LINUX_DEFAULT"'],
+            workdir="/",
+        ).output.decode("utf-8", errors="replace")
+        assert "hugepages=2" in resolved, f"resolved cmdline not refreshed: {resolved!r}"
+        assert "hugepages=8192" not in resolved, f"stale cmdline still resolving: {resolved!r}"
+    finally:
+        runner.cleanup()
+
+
+def test_configure_bootloader_restores_dropin_when_grub_fails(base_image):
+    """A failed regeneration puts the previous drop-in back rather than stranding a new one."""
+    _skip_non_debian(base_image)
+    runner = DockerTestRunner(package="nvidia-tuned", base_image=base_image)
+    try:
+        _rke2_container(runner)
+        _install_grub_stub(runner)
+        _write_bootcmdline(runner, STUB_BOOTCMDLINE, SAMPLE_CMDLINE)
+        assert_exit_code(_run_with_env(runner, "configure_bootloader.sh", RUN_ENV), 0)
+        original = runner.get_file_contents(STUB_DROPIN)
+
+        _install_failing_grub_stub(runner)
+        result = _run_with_env(runner, "configure_bootloader.sh", RUN_ENV)
+        assert result.exit_code != 0, "a failed grub regeneration must fail the step"
+        assert runner.file_exists(STUB_DROPIN), "the previous drop-in was not restored"
+        assert runner.get_file_contents(STUB_DROPIN) == original, \
+            "the restored drop-in does not match what was there before"
+    finally:
+        runner.cleanup()
+
+
+def test_configure_bootloader_removes_new_dropin_when_grub_fails(base_image):
+    """With no previous drop-in, a failed regeneration leaves nothing behind.
+
+    Keeping it would strand a file the generated grub.cfg never referenced, which the
+    next run would then treat as current.
+    """
+    _skip_non_debian(base_image)
+    runner = DockerTestRunner(package="nvidia-tuned", base_image=base_image)
+    try:
+        _rke2_container(runner)
+        _install_failing_grub_stub(runner)
+        _write_bootcmdline(runner, STUB_BOOTCMDLINE, SAMPLE_CMDLINE)
+
+        result = _run_with_env(runner, "configure_bootloader.sh", RUN_ENV)
+        assert result.exit_code != 0, "a failed grub regeneration must fail the step"
+        assert not runner.file_exists(STUB_DROPIN), \
+            "a drop-in grub never accepted must not be left on the host"
+    finally:
+        runner.cleanup()
+
+
+def test_configure_bootloader_skips_system_operations(base_image):
+    """SKIP_SYSTEM_OPERATIONS keeps the step off the real bootloader.
+
+    The suite sets this for every step, so without the guard a missing stub would let a
+    test regenerate the host's GRUB configuration.
+    """
+    _skip_non_debian(base_image)
+    runner = DockerTestRunner(package="nvidia-tuned", base_image=base_image)
+    try:
+        _rke2_container(runner)
+        _install_grub_stub(runner)
+        _write_bootcmdline(runner, STUB_BOOTCMDLINE, SAMPLE_CMDLINE)
+
+        # STUB_ENV keeps the suite-wide SKIP_SYSTEM_OPERATIONS=true in place.
+        result = _run_with_env(runner, "configure_bootloader.sh", STUB_ENV)
+        assert_exit_code(result, 0)
+        assert_output_contains(result.stdout, "SKIP_SYSTEM_OPERATIONS set")
+        assert not runner.file_exists("/tmp/update-grub.ran"), \
+            "update-grub ran despite SKIP_SYSTEM_OPERATIONS"
+        # The drop-in is still written; only the bootloader regeneration is skipped.
+        assert runner.file_exists(STUB_DROPIN)
+    finally:
+        runner.cleanup()
+
+
+def test_configure_bootloader_rejects_unsupported_os(base_image):
+    """RHEL-family nodes fail loudly instead of getting a drop-in grub never reads.
+
+    On the matrix's rockylinux:9 entry this runs against the real /etc/os-release; on the
+    Debian-family entries it runs against a stub, so the path is covered either way.
+    """
+    runner = DockerTestRunner(package="nvidia-tuned", base_image=base_image)
+    try:
+        _rke2_container(runner)
+        _install_grub_stub(runner)
+        _write_bootcmdline(runner, STUB_BOOTCMDLINE, SAMPLE_CMDLINE)
+
+        env = dict(RUN_ENV)
+        if _is_debian_family(base_image):
+            _write_os_release(runner, STUB_OS_RELEASE, RHEL_OS_RELEASE)
+            env["OS_RELEASE"] = STUB_OS_RELEASE
+
+        result = _run_with_env(runner, "configure_bootloader.sh", env)
+        assert result.exit_code != 0, "the step must fail on a distribution it cannot support"
+        assert_output_contains(result.stdout, "does not support the bootloader mechanism")
+        assert not runner.file_exists(STUB_DROPIN), \
+            "no drop-in should be written on a platform that cannot read it"
+        assert not runner.file_exists("/tmp/update-grub.ran"), \
+            "grub must not be regenerated on an unsupported platform"
+    finally:
+        runner.cleanup()
+
+
+def test_configure_bootloader_disabled_by_env(base_image):
+    """CONFIGURE_BOOTLOADER=false is the escape hatch, and silences all three checks.
+
+    This is what an operator sets on a node whose kernel arguments are owned elsewhere,
+    including any RHEL-family node that would otherwise be failed by the OS gate.
+    """
+    runner = DockerTestRunner(package="nvidia-tuned", base_image=base_image)
+    try:
+        _rke2_container(runner)
+        _install_grub_stub(runner)
+        _write_bootcmdline(runner, STUB_BOOTCMDLINE, SAMPLE_CMDLINE)
+
+        env = {**RUN_ENV, "CONFIGURE_BOOTLOADER": "false", "PROC_CMDLINE": STUB_PROC_CMDLINE}
+        for script in (
+            "configure_bootloader.sh",
+            "configure_bootloader_check.sh",
+            "post_interrupt_bootloader_check.sh",
+        ):
+            result = _run_with_env(runner, script, env)
+            assert_exit_code(result, 0)
+            assert_output_contains(result.stdout, "switched off via CONFIGURE_BOOTLOADER")
+
+        assert not runner.file_exists(STUB_DROPIN), "no drop-in should be written when switched off"
+        assert not runner.file_exists("/tmp/update-grub.ran"), "grub must not be regenerated"
     finally:
         runner.cleanup()
 
@@ -1090,15 +1300,14 @@ def test_configure_bootloader_preserves_platform_cmdline(base_image):
     Replacing GRUB_CMDLINE_LINUX_DEFAULT (what the older eks/aks script does) drops the
     serial console arguments an operator needs to reach a node that fails to boot.
     """
+    _skip_non_debian(base_image)
     runner = DockerTestRunner(package="nvidia-tuned", base_image=base_image)
     try:
-        configmaps = {"accelerator": "gb200", "intent": "performance", "service": "rke2"}
-        create_container_for_testing(runner, configmaps)
+        _rke2_container(runner)
         _install_grub_stub(runner)
         _write_bootcmdline(runner, STUB_BOOTCMDLINE, SAMPLE_CMDLINE)
 
-        result = _run_with_env(runner, "configure_bootloader.sh", STUB_ENV)
-        assert_exit_code(result, 0)
+        assert_exit_code(_run_with_env(runner, "configure_bootloader.sh", RUN_ENV), 0)
 
         resolved = runner.container.exec_run(
             [
@@ -1110,15 +1319,18 @@ def test_configure_bootloader_preserves_platform_cmdline(base_image):
             workdir="/",
         ).output.decode("utf-8", errors="replace")
 
-        assert "console=ttyS0,115200n8" in resolved, \
-            f"platform cmdline was dropped: {resolved!r}"
+        assert "console=ttyS0,115200n8" in resolved, f"platform cmdline was dropped: {resolved!r}"
         assert "hugepages=8192" in resolved, f"profile cmdline was not appended: {resolved!r}"
     finally:
         runner.cleanup()
 
 
 def test_configure_bootloader_noop_for_other_service(base_image):
-    """Services without the marker (bcm here) get no drop-in and no grub regeneration."""
+    """Services without the marker (bcm here) get no drop-in and no grub regeneration.
+
+    The service gate is checked before the OS gate, so this holds on every base image:
+    a service that never wanted a drop-in is not failed for the platform it runs on.
+    """
     runner = DockerTestRunner(package="nvidia-tuned", base_image=base_image)
     try:
         configmaps = {"accelerator": "gb200", "intent": "performance", "service": "bcm"}
@@ -1126,14 +1338,13 @@ def test_configure_bootloader_noop_for_other_service(base_image):
         _install_grub_stub(runner)
         _write_bootcmdline(runner, STUB_BOOTCMDLINE, SAMPLE_CMDLINE)
 
-        result = _run_with_env(runner, "configure_bootloader.sh", STUB_ENV)
+        result = _run_with_env(runner, "configure_bootloader.sh", RUN_ENV)
         assert_exit_code(result, 0)
         assert_output_contains(result.stdout, "not enabled for this service")
         assert not runner.file_exists(STUB_DROPIN), \
             "bcm must not get a bootloader drop-in; it applies without a reboot"
 
-        # And its check is a no-op rather than a failure.
-        check = _run_with_env(runner, "configure_bootloader_check.sh", STUB_ENV)
+        check = _run_with_env(runner, "configure_bootloader_check.sh", RUN_ENV)
         assert_exit_code(check, 0)
     finally:
         runner.cleanup()
@@ -1141,20 +1352,20 @@ def test_configure_bootloader_noop_for_other_service(base_image):
 
 def test_configure_bootloader_stands_down_when_service_changes(base_image):
     """Switching off rke2 removes the drop-in rather than leaving it applying forever."""
+    _skip_non_debian(base_image)
     runner = DockerTestRunner(package="nvidia-tuned", base_image=base_image)
     try:
-        configmaps = {"accelerator": "gb200", "intent": "performance", "service": "rke2"}
-        create_container_for_testing(runner, configmaps)
+        _rke2_container(runner)
         _install_grub_stub(runner)
         _write_bootcmdline(runner, STUB_BOOTCMDLINE, SAMPLE_CMDLINE)
 
-        assert_exit_code(_run_with_env(runner, "configure_bootloader.sh", STUB_ENV), 0)
+        assert_exit_code(_run_with_env(runner, "configure_bootloader.sh", RUN_ENV), 0)
         assert runner.file_exists(STUB_DROPIN)
 
         runner.container.exec_run(
             ["bash", "-c", "echo bcm > /skyhook-package/configmaps/service"], workdir="/"
         )
-        result = _run_with_env(runner, "configure_bootloader.sh", STUB_ENV)
+        result = _run_with_env(runner, "configure_bootloader.sh", RUN_ENV)
         assert_exit_code(result, 0)
         assert not runner.file_exists(STUB_DROPIN), \
             "drop-in must be removed once the service stops opting in"
@@ -1164,13 +1375,13 @@ def test_configure_bootloader_stands_down_when_service_changes(base_image):
 
 def test_configure_bootloader_check_fails_without_dropin(base_image):
     """The check fails when the step was requested but left nothing behind."""
+    _skip_non_debian(base_image)
     runner = DockerTestRunner(package="nvidia-tuned", base_image=base_image)
     try:
-        configmaps = {"accelerator": "gb200", "intent": "performance", "service": "rke2"}
-        create_container_for_testing(runner, configmaps)
+        _rke2_container(runner)
         _write_bootcmdline(runner, STUB_BOOTCMDLINE, SAMPLE_CMDLINE)
 
-        result = _run_with_env(runner, "configure_bootloader_check.sh", STUB_ENV)
+        result = _run_with_env(runner, "configure_bootloader_check.sh", RUN_ENV)
         assert result.exit_code != 0, "check should fail when no drop-in exists"
         assert_output_contains(result.stdout, "no drop-in exists")
     finally:
@@ -1183,10 +1394,10 @@ def test_configure_bootloader_check_fails_on_inert_dropin(base_image):
     This is the failure worth catching early: a commented-out or overwritten drop-in
     reads as installed but leaves the node booting untuned.
     """
+    _skip_non_debian(base_image)
     runner = DockerTestRunner(package="nvidia-tuned", base_image=base_image)
     try:
-        configmaps = {"accelerator": "gb200", "intent": "performance", "service": "rke2"}
-        create_container_for_testing(runner, configmaps)
+        _rke2_container(runner)
         _write_bootcmdline(runner, STUB_BOOTCMDLINE, SAMPLE_CMDLINE)
         runner.container.exec_run(
             [
@@ -1198,7 +1409,7 @@ def test_configure_bootloader_check_fails_on_inert_dropin(base_image):
             workdir="/",
         )
 
-        result = _run_with_env(runner, "configure_bootloader_check.sh", STUB_ENV)
+        result = _run_with_env(runner, "configure_bootloader_check.sh", RUN_ENV)
         assert result.exit_code != 0, "check should fail on a drop-in that resolves to nothing"
         assert_output_contains(result.stdout, "does not resolve to the profile's cmdline")
     finally:
@@ -1207,20 +1418,20 @@ def test_configure_bootloader_check_fails_on_inert_dropin(base_image):
 
 def test_post_interrupt_bootloader_check_passes_when_cmdline_live(base_image):
     """After the reboot, every profile argument is present on the booted cmdline."""
+    _skip_non_debian(base_image)
     runner = DockerTestRunner(package="nvidia-tuned", base_image=base_image)
     try:
-        configmaps = {"accelerator": "gb200", "intent": "performance", "service": "rke2"}
-        create_container_for_testing(runner, configmaps)
+        _rke2_container(runner)
         _write_bootcmdline(runner, STUB_BOOTCMDLINE, SAMPLE_CMDLINE)
         runner.container.exec_run(
-            ["bash", "-c", f"printf 'BOOT_IMAGE=/vmlinuz ro %s\\n' '{SAMPLE_CMDLINE}' > {STUB_PROC_CMDLINE}"],
+            ["bash", "-c",
+             f"printf 'BOOT_IMAGE=/vmlinuz ro %s\\n' '{SAMPLE_CMDLINE}' > {STUB_PROC_CMDLINE}"],
             workdir="/",
         )
 
         result = _run_with_env(
-            runner,
-            "post_interrupt_bootloader_check.sh",
-            {**STUB_ENV, "PROC_CMDLINE": STUB_PROC_CMDLINE},
+            runner, "post_interrupt_bootloader_check.sh",
+            {**RUN_ENV, "PROC_CMDLINE": STUB_PROC_CMDLINE},
         )
         assert_exit_code(result, 0)
         assert_output_contains(result.stdout, "live after reboot")
@@ -1230,10 +1441,10 @@ def test_post_interrupt_bootloader_check_passes_when_cmdline_live(base_image):
 
 def test_post_interrupt_bootloader_check_fails_when_cmdline_absent(base_image):
     """A reboot that did not pick the drop-in up fails the node rather than passing it."""
+    _skip_non_debian(base_image)
     runner = DockerTestRunner(package="nvidia-tuned", base_image=base_image)
     try:
-        configmaps = {"accelerator": "gb200", "intent": "performance", "service": "rke2"}
-        create_container_for_testing(runner, configmaps)
+        _rke2_container(runner)
         _write_bootcmdline(runner, STUB_BOOTCMDLINE, SAMPLE_CMDLINE)
         # Booted without the profile arguments, e.g. a later-sorting grub.d file won.
         runner.container.exec_run(
@@ -1242,9 +1453,8 @@ def test_post_interrupt_bootloader_check_fails_when_cmdline_absent(base_image):
         )
 
         result = _run_with_env(
-            runner,
-            "post_interrupt_bootloader_check.sh",
-            {**STUB_ENV, "PROC_CMDLINE": STUB_PROC_CMDLINE},
+            runner, "post_interrupt_bootloader_check.sh",
+            {**RUN_ENV, "PROC_CMDLINE": STUB_PROC_CMDLINE},
         )
         assert result.exit_code != 0, "check should fail when the cmdline did not take effect"
         assert_output_contains(result.stdout, "did not take effect")
@@ -1255,22 +1465,43 @@ def test_post_interrupt_bootloader_check_fails_when_cmdline_absent(base_image):
 
 def test_uninstall_bootloader_removes_dropin(base_image):
     """Uninstall removes the drop-in so the cmdline does not outlive the package."""
+    _skip_non_debian(base_image)
     runner = DockerTestRunner(package="nvidia-tuned", base_image=base_image)
     try:
-        configmaps = {"accelerator": "gb200", "intent": "performance", "service": "rke2"}
-        create_container_for_testing(runner, configmaps)
+        _rke2_container(runner)
         _install_grub_stub(runner)
         _write_bootcmdline(runner, STUB_BOOTCMDLINE, SAMPLE_CMDLINE)
 
-        assert_exit_code(_run_with_env(runner, "configure_bootloader.sh", STUB_ENV), 0)
+        assert_exit_code(_run_with_env(runner, "configure_bootloader.sh", RUN_ENV), 0)
         assert runner.file_exists(STUB_DROPIN)
 
-        result = _run_with_env(runner, "uninstall_bootloader.sh", STUB_ENV)
+        result = _run_with_env(runner, "uninstall_bootloader.sh", RUN_ENV)
         assert_exit_code(result, 0)
         assert not runner.file_exists(STUB_DROPIN), "uninstall left the drop-in behind"
 
-        check = _run_with_env(runner, "uninstall_bootloader_check.sh", STUB_ENV)
+        check = _run_with_env(runner, "uninstall_bootloader_check.sh", RUN_ENV)
         assert_exit_code(check, 0)
+    finally:
+        runner.cleanup()
+
+
+def test_uninstall_bootloader_skips_system_operations(base_image):
+    """Uninstall honours SKIP_SYSTEM_OPERATIONS too; it is a registered lifecycle step."""
+    _skip_non_debian(base_image)
+    runner = DockerTestRunner(package="nvidia-tuned", base_image=base_image)
+    try:
+        _rke2_container(runner)
+        _install_grub_stub(runner)
+        _write_bootcmdline(runner, STUB_BOOTCMDLINE, SAMPLE_CMDLINE)
+        assert_exit_code(_run_with_env(runner, "configure_bootloader.sh", RUN_ENV), 0)
+        runner.container.exec_run(["bash", "-c", "rm -f /tmp/update-grub.ran"], workdir="/")
+
+        result = _run_with_env(runner, "uninstall_bootloader.sh", STUB_ENV)
+        assert_exit_code(result, 0)
+        assert_output_contains(result.stdout, "SKIP_SYSTEM_OPERATIONS set")
+        assert not runner.file_exists("/tmp/update-grub.ran"), \
+            "update-grub ran despite SKIP_SYSTEM_OPERATIONS"
+        assert not runner.file_exists(STUB_DROPIN), "the drop-in should still be removed"
     finally:
         runner.cleanup()
 
@@ -1279,10 +1510,9 @@ def test_uninstall_bootloader_is_idempotent(base_image):
     """Removing a drop-in that was never written is a no-op, not a failure."""
     runner = DockerTestRunner(package="nvidia-tuned", base_image=base_image)
     try:
-        configmaps = {"accelerator": "gb200", "intent": "performance", "service": "rke2"}
-        create_container_for_testing(runner, configmaps)
+        _rke2_container(runner)
 
-        result = _run_with_env(runner, "uninstall_bootloader.sh", STUB_ENV)
+        result = _run_with_env(runner, "uninstall_bootloader.sh", RUN_ENV)
         assert_exit_code(result, 0)
         assert_output_contains(result.stdout, "nothing to remove")
     finally:
@@ -1312,10 +1542,9 @@ def test_configure_bootloader_leaves_foreign_dropin_alone(base_image):
             workdir="/",
         )
 
-        result = _run_with_env(runner, "configure_bootloader.sh", STUB_ENV)
+        result = _run_with_env(runner, "configure_bootloader.sh", RUN_ENV)
         assert_exit_code(result, 0)
-        assert runner.file_exists(STUB_DROPIN), \
-            "the step removed a drop-in another service owns"
+        assert runner.file_exists(STUB_DROPIN), "the step removed a drop-in another service owns"
         assert "GRUB_CMDLINE_LINUX_DEFAULT" in runner.get_file_contents(STUB_DROPIN), \
             "the foreign drop-in was modified"
     finally:
@@ -1339,14 +1568,12 @@ def test_uninstall_bootloader_leaves_foreign_dropin_alone(base_image):
             workdir="/",
         )
 
-        result = _run_with_env(runner, "uninstall_bootloader.sh", STUB_ENV)
+        result = _run_with_env(runner, "uninstall_bootloader.sh", RUN_ENV)
         assert_exit_code(result, 0)
         assert_output_contains(result.stdout, "nothing to remove")
-        assert runner.file_exists(STUB_DROPIN), \
-            "uninstall removed a drop-in another service owns"
+        assert runner.file_exists(STUB_DROPIN), "uninstall removed a drop-in another service owns"
 
-        # And the uninstall check does not report a failed uninstall for it either.
-        check = _run_with_env(runner, "uninstall_bootloader_check.sh", STUB_ENV)
+        check = _run_with_env(runner, "uninstall_bootloader_check.sh", RUN_ENV)
         assert_exit_code(check, 0)
     finally:
         runner.cleanup()

--- a/tests/integration/nvidia_tuned/test_prepare_nvidia_profiles.py
+++ b/tests/integration/nvidia_tuned/test_prepare_nvidia_profiles.py
@@ -24,9 +24,11 @@ Tests verify:
 - prepare_nvidia_profiles does the right thing for all combinations of:
   - accelerator (h100, gb200, generic)
   - intent (performance, inference, multiNodeTraining)
-  - service (eks, none)
+  - service (eks, aks, bcm, rke2, none)
 - accelerator=generic uses self-contained nvidia-generic profile, ignoring intent and service
 - For AWS service, verifies grub config file is created correctly
+- For the rke2 service, verifies the [bootloader] chain survives and the grub.d drop-in,
+  its checks, and its teardown behave
 """
 
 import pytest
@@ -875,5 +877,476 @@ def test_prepare_nvidia_profiles_vr200_bcm_no_bootloader(base_image, intent):
             f"{profiles_dir}/nvidia-vr200-noreboot-base/tuned.conf"
         )
         assert "[bootloader]" not in noreboot, "noreboot base must not have [bootloader]"
+    finally:
+        runner.cleanup()
+
+
+# --- rke2 service -------------------------------------------------------------------
+#
+# rke2 is the mirror image of bcm for the same accelerators: bcm re-roots onto a
+# bootloader-free base so nothing needs a reboot, rke2 ships no overrides at all so each
+# accelerator keeps its own [bootloader] stanza and the node reboots to pick it up.
+
+# (accelerator, intent) pairs rke2 supports. gb300 ships a performance profile only.
+RKE2_PAIRS = [
+    ("gb200", "performance"),
+    ("gb200", "inference"),
+    ("gb200", "multiNodeTraining"),
+    ("gb300", "performance"),
+    ("vr200", "performance"),
+    ("vr200", "inference"),
+    ("vr200", "multiNodeTraining"),
+]
+
+# Accelerators whose performance profile carries a [script] stanza that a service-level
+# [script] would suppress. See test_prepare_nvidia_profiles_rke2_ships_no_script.
+ACCELERATORS_WITH_CONTAINERD_SCRIPT = ("gb200", "vr200")
+
+
+class _ScriptResult:
+    """Mirrors the TestResult shape run_script_in_container returns."""
+
+    def __init__(self, exit_code, stdout):
+        self.exit_code = exit_code
+        self.stdout = stdout
+        self.stderr = ""
+
+
+def _skip_unsupported_accelerator(base_image, accelerator):
+    """vr200 profiles only exist under os/ubuntu/26.04; everything else is in os/common."""
+    if accelerator == "vr200":
+        _require_ubuntu_2604(base_image)
+
+
+def _run_with_env(runner: DockerTestRunner, script: str, env: dict) -> _ScriptResult:
+    """Run a lifecycle script with extra env layered onto the standard package env."""
+    if runner.container is None:
+        raise RuntimeError("Container must exist before running script")
+    container_env = {
+        "SKYHOOK_DIR": "/skyhook-package",
+        "STEP_ROOT": "/skyhook-package/skyhook_dir",
+        "SKIP_SYSTEM_OPERATIONS": "true",
+        **env,
+    }
+    exec_result = runner.container.exec_run(
+        ["/bin/bash", "-c", f"bash /skyhook-package/skyhook_dir/{script} 2>&1"],
+        workdir="/skyhook-package",
+        environment=container_env,
+    )
+    return _ScriptResult(exec_result.exit_code, exec_result.output.decode("utf-8", errors="replace"))
+
+
+def _install_grub_stub(runner: DockerTestRunner):
+    """Stub update-grub so the step's regeneration succeeds without a bootloader."""
+    runner.container.exec_run(
+        [
+            "bash",
+            "-c",
+            "printf '#!/bin/sh\\ntouch /tmp/update-grub.ran\\n' > /usr/local/bin/update-grub "
+            "&& chmod +x /usr/local/bin/update-grub",
+        ],
+        workdir="/",
+    )
+
+
+def _write_bootcmdline(runner: DockerTestRunner, path: str, cmdline: str):
+    """Stand in for tuned resolving a profile's [bootloader] stanza."""
+    runner.container.exec_run(
+        ["bash", "-c", f"mkdir -p $(dirname {path}) && printf 'TUNED_BOOT_CMDLINE=\"%s\"\\n' '{cmdline}' > {path}"],
+        workdir="/",
+    )
+
+
+# Paths the bootloader scripts take from the environment so tests do not touch real grub.
+STUB_DROPIN = "/tmp/grub.d/99-nvidia-tuned-cmdline.cfg"
+STUB_BOOTCMDLINE = "/tmp/tuned-bootcmdline"
+STUB_PROC_CMDLINE = "/tmp/proc-cmdline"
+STUB_ENV = {"TUNED_GRUB_DROPIN": STUB_DROPIN, "TUNED_BOOTCMDLINE": STUB_BOOTCMDLINE}
+
+SAMPLE_CMDLINE = "iommu.passthrough=1 numa_balancing=disable hugepagesz=2M hugepages=8192"
+
+
+@pytest.mark.parametrize("accelerator,intent", RKE2_PAIRS)
+def test_prepare_nvidia_profiles_rke2_keeps_bootloader(base_image, accelerator, intent):
+    """rke2 leaves the accelerator's [bootloader] chain intact, unlike bcm."""
+    _skip_unsupported_accelerator(base_image, accelerator)
+    runner = DockerTestRunner(package="nvidia-tuned", base_image=base_image)
+    try:
+        configmaps = {"accelerator": accelerator, "intent": intent, "service": "rke2"}
+        create_container_for_testing(runner, configmaps)
+        result = run_script_in_container(runner, "prepare_nvidia_profiles.sh", configmaps)
+
+        assert_exit_code(result, 0)
+        profiles_dir = expected_profiles_dir(runner)
+        final_profile = f"rke2-{accelerator}-{intent}"
+        workload_profile = f"nvidia-{accelerator}-{intent}"
+
+        assert runner.file_exists(f"{profiles_dir}/{final_profile}/tuned.conf"), \
+            f"rke2 service profile {final_profile} was not deployed to {profiles_dir}/"
+
+        service_content = runner.get_file_contents(f"{profiles_dir}/{final_profile}/tuned.conf")
+        assert f"include={workload_profile}" in service_content, \
+            f"rke2 profile must include {workload_profile}, got: {service_content!r}"
+
+        # The crux of the difference from bcm: no override re-roots the workload profile
+        # onto a bootloader-free base, so it is the stock OS profile.
+        workload_content = runner.get_file_contents(f"{profiles_dir}/{workload_profile}/tuned.conf")
+        assert "noreboot-base" not in workload_content, \
+            f"rke2 must not re-root {workload_profile} onto a bootloader-free base"
+
+        # The root of every rke2 chain is the accelerator's performance profile, which is
+        # where the kernel command line lives.
+        perf_content = runner.get_file_contents(
+            f"{profiles_dir}/nvidia-{accelerator}-performance/tuned.conf"
+        )
+        assert re.search(r"^\[bootloader\]", perf_content, re.MULTILINE) is not None, \
+            f"nvidia-{accelerator}-performance should carry a [bootloader] section for rke2 to apply"
+    finally:
+        runner.cleanup()
+
+
+@pytest.mark.parametrize("accelerator", ACCELERATORS_WITH_CONTAINERD_SCRIPT)
+def test_prepare_nvidia_profiles_rke2_ships_no_script(base_image, accelerator):
+    """rke2's template declares no [script], so the base profile's script survives.
+
+    Only one [script] survives tuned's include chain. A service-level stanza (as eks,
+    aks and oci declare) would silently suppress containerd_service.sh on exactly the
+    accelerators rke2 targets, dropping the containerd LimitSTACK drop-in.
+    """
+    _skip_unsupported_accelerator(base_image, accelerator)
+    runner = DockerTestRunner(package="nvidia-tuned", base_image=base_image)
+    try:
+        configmaps = {"accelerator": accelerator, "intent": "performance", "service": "rke2"}
+        create_container_for_testing(runner, configmaps)
+        result = run_script_in_container(runner, "prepare_nvidia_profiles.sh", configmaps)
+
+        assert_exit_code(result, 0)
+        profiles_dir = expected_profiles_dir(runner)
+
+        service_content = runner.get_file_contents(
+            f"{profiles_dir}/rke2-{accelerator}-performance/tuned.conf"
+        )
+        assert re.search(r"^\[script\]", service_content, re.MULTILINE) is None, \
+            "rke2 must not declare a [script] section; it would suppress the base profile's script"
+
+        assert runner.file_exists(
+            f"{profiles_dir}/nvidia-{accelerator}-performance/containerd_service.sh"
+        ), f"containerd_service.sh missing from nvidia-{accelerator}-performance"
+    finally:
+        runner.cleanup()
+
+
+def test_prepare_nvidia_profiles_rke2_marker_not_deployed(base_image):
+    """The bootloader.enabled marker is read by the agent step, so tuned never sees it."""
+    runner = DockerTestRunner(package="nvidia-tuned", base_image=base_image)
+    try:
+        configmaps = {"accelerator": "gb200", "intent": "performance", "service": "rke2"}
+        create_container_for_testing(runner, configmaps)
+        result = run_script_in_container(runner, "prepare_nvidia_profiles.sh", configmaps)
+
+        assert_exit_code(result, 0)
+        profiles_dir = expected_profiles_dir(runner)
+        assert not runner.file_exists(f"{profiles_dir}/rke2-gb200-performance/bootloader.enabled"), \
+            "bootloader.enabled must not be copied into the tuned profile directory"
+        # It must still be readable where the lifecycle step looks for it.
+        assert runner.file_exists("/skyhook-package/profiles/service/rke2/bootloader.enabled"), \
+            "bootloader.enabled must remain in the package for configure_bootloader.sh to gate on"
+    finally:
+        runner.cleanup()
+
+
+def test_configure_bootloader_writes_dropin(base_image):
+    """configure_bootloader.sh writes a drop-in that resolves to the profile cmdline."""
+    runner = DockerTestRunner(package="nvidia-tuned", base_image=base_image)
+    try:
+        configmaps = {"accelerator": "gb200", "intent": "performance", "service": "rke2"}
+        create_container_for_testing(runner, configmaps)
+        _install_grub_stub(runner)
+        _write_bootcmdline(runner, STUB_BOOTCMDLINE, SAMPLE_CMDLINE)
+
+        result = _run_with_env(runner, "configure_bootloader.sh", STUB_ENV)
+        assert_exit_code(result, 0)
+        assert runner.file_exists(STUB_DROPIN), f"drop-in was not written to {STUB_DROPIN}"
+        assert runner.file_exists("/tmp/update-grub.ran"), "grub was not regenerated"
+
+        # Evaluate the drop-in the way grub will, rather than matching its text.
+        resolved = runner.container.exec_run(
+            ["bash", "-c", f'. {STUB_DROPIN}; printf "%s" "$GRUB_CMDLINE_LINUX_DEFAULT"'],
+            workdir="/",
+        ).output.decode("utf-8", errors="replace")
+        for token in SAMPLE_CMDLINE.split():
+            assert token in resolved, f"{token} missing from resolved cmdline: {resolved!r}"
+
+        # The check step agrees.
+        check = _run_with_env(runner, "configure_bootloader_check.sh", STUB_ENV)
+        assert_exit_code(check, 0)
+    finally:
+        runner.cleanup()
+
+
+def test_configure_bootloader_preserves_platform_cmdline(base_image):
+    """The drop-in appends, so the platform's own arguments survive.
+
+    Replacing GRUB_CMDLINE_LINUX_DEFAULT (what the older eks/aks script does) drops the
+    serial console arguments an operator needs to reach a node that fails to boot.
+    """
+    runner = DockerTestRunner(package="nvidia-tuned", base_image=base_image)
+    try:
+        configmaps = {"accelerator": "gb200", "intent": "performance", "service": "rke2"}
+        create_container_for_testing(runner, configmaps)
+        _install_grub_stub(runner)
+        _write_bootcmdline(runner, STUB_BOOTCMDLINE, SAMPLE_CMDLINE)
+
+        result = _run_with_env(runner, "configure_bootloader.sh", STUB_ENV)
+        assert_exit_code(result, 0)
+
+        resolved = runner.container.exec_run(
+            [
+                "bash",
+                "-c",
+                f'GRUB_CMDLINE_LINUX_DEFAULT="console=ttyS0,115200n8 quiet"; '
+                f'. {STUB_DROPIN}; printf "%s" "$GRUB_CMDLINE_LINUX_DEFAULT"',
+            ],
+            workdir="/",
+        ).output.decode("utf-8", errors="replace")
+
+        assert "console=ttyS0,115200n8" in resolved, \
+            f"platform cmdline was dropped: {resolved!r}"
+        assert "hugepages=8192" in resolved, f"profile cmdline was not appended: {resolved!r}"
+    finally:
+        runner.cleanup()
+
+
+def test_configure_bootloader_noop_for_other_service(base_image):
+    """Services without the marker (bcm here) get no drop-in and no grub regeneration."""
+    runner = DockerTestRunner(package="nvidia-tuned", base_image=base_image)
+    try:
+        configmaps = {"accelerator": "gb200", "intent": "performance", "service": "bcm"}
+        create_container_for_testing(runner, configmaps)
+        _install_grub_stub(runner)
+        _write_bootcmdline(runner, STUB_BOOTCMDLINE, SAMPLE_CMDLINE)
+
+        result = _run_with_env(runner, "configure_bootloader.sh", STUB_ENV)
+        assert_exit_code(result, 0)
+        assert_output_contains(result.stdout, "not enabled for this service")
+        assert not runner.file_exists(STUB_DROPIN), \
+            "bcm must not get a bootloader drop-in; it applies without a reboot"
+
+        # And its check is a no-op rather than a failure.
+        check = _run_with_env(runner, "configure_bootloader_check.sh", STUB_ENV)
+        assert_exit_code(check, 0)
+    finally:
+        runner.cleanup()
+
+
+def test_configure_bootloader_stands_down_when_service_changes(base_image):
+    """Switching off rke2 removes the drop-in rather than leaving it applying forever."""
+    runner = DockerTestRunner(package="nvidia-tuned", base_image=base_image)
+    try:
+        configmaps = {"accelerator": "gb200", "intent": "performance", "service": "rke2"}
+        create_container_for_testing(runner, configmaps)
+        _install_grub_stub(runner)
+        _write_bootcmdline(runner, STUB_BOOTCMDLINE, SAMPLE_CMDLINE)
+
+        assert_exit_code(_run_with_env(runner, "configure_bootloader.sh", STUB_ENV), 0)
+        assert runner.file_exists(STUB_DROPIN)
+
+        runner.container.exec_run(
+            ["bash", "-c", "echo bcm > /skyhook-package/configmaps/service"], workdir="/"
+        )
+        result = _run_with_env(runner, "configure_bootloader.sh", STUB_ENV)
+        assert_exit_code(result, 0)
+        assert not runner.file_exists(STUB_DROPIN), \
+            "drop-in must be removed once the service stops opting in"
+    finally:
+        runner.cleanup()
+
+
+def test_configure_bootloader_check_fails_without_dropin(base_image):
+    """The check fails when the step was requested but left nothing behind."""
+    runner = DockerTestRunner(package="nvidia-tuned", base_image=base_image)
+    try:
+        configmaps = {"accelerator": "gb200", "intent": "performance", "service": "rke2"}
+        create_container_for_testing(runner, configmaps)
+        _write_bootcmdline(runner, STUB_BOOTCMDLINE, SAMPLE_CMDLINE)
+
+        result = _run_with_env(runner, "configure_bootloader_check.sh", STUB_ENV)
+        assert result.exit_code != 0, "check should fail when no drop-in exists"
+        assert_output_contains(result.stdout, "no drop-in exists")
+    finally:
+        runner.cleanup()
+
+
+def test_configure_bootloader_check_fails_on_inert_dropin(base_image):
+    """A drop-in that is present but contributes nothing fails before the reboot.
+
+    This is the failure worth catching early: a commented-out or overwritten drop-in
+    reads as installed but leaves the node booting untuned.
+    """
+    runner = DockerTestRunner(package="nvidia-tuned", base_image=base_image)
+    try:
+        configmaps = {"accelerator": "gb200", "intent": "performance", "service": "rke2"}
+        create_container_for_testing(runner, configmaps)
+        _write_bootcmdline(runner, STUB_BOOTCMDLINE, SAMPLE_CMDLINE)
+        runner.container.exec_run(
+            [
+                "bash",
+                "-c",
+                f"mkdir -p $(dirname {STUB_DROPIN}) && "
+                f"printf '# everything here is commented out\\n' > {STUB_DROPIN}",
+            ],
+            workdir="/",
+        )
+
+        result = _run_with_env(runner, "configure_bootloader_check.sh", STUB_ENV)
+        assert result.exit_code != 0, "check should fail on a drop-in that resolves to nothing"
+        assert_output_contains(result.stdout, "does not resolve to the profile's cmdline")
+    finally:
+        runner.cleanup()
+
+
+def test_post_interrupt_bootloader_check_passes_when_cmdline_live(base_image):
+    """After the reboot, every profile argument is present on the booted cmdline."""
+    runner = DockerTestRunner(package="nvidia-tuned", base_image=base_image)
+    try:
+        configmaps = {"accelerator": "gb200", "intent": "performance", "service": "rke2"}
+        create_container_for_testing(runner, configmaps)
+        _write_bootcmdline(runner, STUB_BOOTCMDLINE, SAMPLE_CMDLINE)
+        runner.container.exec_run(
+            ["bash", "-c", f"printf 'BOOT_IMAGE=/vmlinuz ro %s\\n' '{SAMPLE_CMDLINE}' > {STUB_PROC_CMDLINE}"],
+            workdir="/",
+        )
+
+        result = _run_with_env(
+            runner,
+            "post_interrupt_bootloader_check.sh",
+            {**STUB_ENV, "PROC_CMDLINE": STUB_PROC_CMDLINE},
+        )
+        assert_exit_code(result, 0)
+        assert_output_contains(result.stdout, "live after reboot")
+    finally:
+        runner.cleanup()
+
+
+def test_post_interrupt_bootloader_check_fails_when_cmdline_absent(base_image):
+    """A reboot that did not pick the drop-in up fails the node rather than passing it."""
+    runner = DockerTestRunner(package="nvidia-tuned", base_image=base_image)
+    try:
+        configmaps = {"accelerator": "gb200", "intent": "performance", "service": "rke2"}
+        create_container_for_testing(runner, configmaps)
+        _write_bootcmdline(runner, STUB_BOOTCMDLINE, SAMPLE_CMDLINE)
+        # Booted without the profile arguments, e.g. a later-sorting grub.d file won.
+        runner.container.exec_run(
+            ["bash", "-c", f"printf 'BOOT_IMAGE=/vmlinuz ro quiet\\n' > {STUB_PROC_CMDLINE}"],
+            workdir="/",
+        )
+
+        result = _run_with_env(
+            runner,
+            "post_interrupt_bootloader_check.sh",
+            {**STUB_ENV, "PROC_CMDLINE": STUB_PROC_CMDLINE},
+        )
+        assert result.exit_code != 0, "check should fail when the cmdline did not take effect"
+        assert_output_contains(result.stdout, "did not take effect")
+        assert_output_contains(result.stdout, "hugepages=8192")
+    finally:
+        runner.cleanup()
+
+
+def test_uninstall_bootloader_removes_dropin(base_image):
+    """Uninstall removes the drop-in so the cmdline does not outlive the package."""
+    runner = DockerTestRunner(package="nvidia-tuned", base_image=base_image)
+    try:
+        configmaps = {"accelerator": "gb200", "intent": "performance", "service": "rke2"}
+        create_container_for_testing(runner, configmaps)
+        _install_grub_stub(runner)
+        _write_bootcmdline(runner, STUB_BOOTCMDLINE, SAMPLE_CMDLINE)
+
+        assert_exit_code(_run_with_env(runner, "configure_bootloader.sh", STUB_ENV), 0)
+        assert runner.file_exists(STUB_DROPIN)
+
+        result = _run_with_env(runner, "uninstall_bootloader.sh", STUB_ENV)
+        assert_exit_code(result, 0)
+        assert not runner.file_exists(STUB_DROPIN), "uninstall left the drop-in behind"
+
+        check = _run_with_env(runner, "uninstall_bootloader_check.sh", STUB_ENV)
+        assert_exit_code(check, 0)
+    finally:
+        runner.cleanup()
+
+
+def test_uninstall_bootloader_is_idempotent(base_image):
+    """Removing a drop-in that was never written is a no-op, not a failure."""
+    runner = DockerTestRunner(package="nvidia-tuned", base_image=base_image)
+    try:
+        configmaps = {"accelerator": "gb200", "intent": "performance", "service": "rke2"}
+        create_container_for_testing(runner, configmaps)
+
+        result = _run_with_env(runner, "uninstall_bootloader.sh", STUB_ENV)
+        assert_exit_code(result, 0)
+        assert_output_contains(result.stdout, "nothing to remove")
+    finally:
+        runner.cleanup()
+
+
+def test_configure_bootloader_leaves_foreign_dropin_alone(base_image):
+    """Standing down must not delete a drop-in this package did not write.
+
+    The eks and aks services write their own grub.d file from inside the tuned profile,
+    and configure-bootloader runs after the profile is applied. Removing anything without
+    its own marker would silently undo them on every config pass.
+    """
+    runner = DockerTestRunner(package="nvidia-tuned", base_image=base_image)
+    try:
+        configmaps = {"accelerator": "h100", "intent": "inference", "service": "eks"}
+        create_container_for_testing(runner, configmaps)
+        _install_grub_stub(runner)
+        _write_bootcmdline(runner, STUB_BOOTCMDLINE, SAMPLE_CMDLINE)
+        runner.container.exec_run(
+            [
+                "bash",
+                "-c",
+                f"mkdir -p $(dirname {STUB_DROPIN}) && "
+                f"printf 'GRUB_CMDLINE_LINUX_DEFAULT=\" ${{TUNED_BOOT_CMDLINE}}\"\\n' > {STUB_DROPIN}",
+            ],
+            workdir="/",
+        )
+
+        result = _run_with_env(runner, "configure_bootloader.sh", STUB_ENV)
+        assert_exit_code(result, 0)
+        assert runner.file_exists(STUB_DROPIN), \
+            "the step removed a drop-in another service owns"
+        assert "GRUB_CMDLINE_LINUX_DEFAULT" in runner.get_file_contents(STUB_DROPIN), \
+            "the foreign drop-in was modified"
+    finally:
+        runner.cleanup()
+
+
+def test_uninstall_bootloader_leaves_foreign_dropin_alone(base_image):
+    """Uninstall is scoped to the drop-in this package wrote, by marker."""
+    runner = DockerTestRunner(package="nvidia-tuned", base_image=base_image)
+    try:
+        configmaps = {"accelerator": "h100", "intent": "inference", "service": "eks"}
+        create_container_for_testing(runner, configmaps)
+        _install_grub_stub(runner)
+        runner.container.exec_run(
+            [
+                "bash",
+                "-c",
+                f"mkdir -p $(dirname {STUB_DROPIN}) && "
+                f"printf 'GRUB_CMDLINE_LINUX_DEFAULT=\" ${{TUNED_BOOT_CMDLINE}}\"\\n' > {STUB_DROPIN}",
+            ],
+            workdir="/",
+        )
+
+        result = _run_with_env(runner, "uninstall_bootloader.sh", STUB_ENV)
+        assert_exit_code(result, 0)
+        assert_output_contains(result.stdout, "nothing to remove")
+        assert runner.file_exists(STUB_DROPIN), \
+            "uninstall removed a drop-in another service owns"
+
+        # And the uninstall check does not report a failed uninstall for it either.
+        check = _run_with_env(runner, "uninstall_bootloader_check.sh", STUB_ENV)
+        assert_exit_code(check, 0)
     finally:
         runner.cleanup()


### PR DESCRIPTION
## Description

Adds an `rke2` service to `nvidia-tuned` that keeps the accelerator's reboot-requiring
`[bootloader]` tuning instead of stripping it, plus a `configure-bootloader` lifecycle
step that actually lands it on the host.

`bcm` and `rke2` are two halves of the same trade for the same accelerators. `bcm`
re-roots onto a bootloader-free base so nothing needs a reboot; `rke2` ships no profile
overrides at all, so each accelerator falls through to its own workload profile with the
`[bootloader]` stanza intact and the node reboots to pick it up. A custom resource
selecting `service=rke2` must declare `interrupt: {type: reboot}`.

Supported on `gb200` and `vr200` across all three intents, and on `gb300` for
`performance`, the only intent that accelerator ships.

### Why the step is not a tuned `[script]`

Keeping the stanza is not sufficient by itself. tuned resolves it to
`/etc/tuned/bootcmdline` and then rewrites `/etc/default/grub`, but Ubuntu builds
`GRUB_CMDLINE_LINUX_DEFAULT` from `/etc/default/grub.d/`, so that rewrite is ignored and
the cmdline never reaches the kernel. `eks` and `aks` close that gap with a `[script]`
in the service profile, but only one `[script]` survives tuned's include chain, so a
service-level stanza suppresses the `containerd_service.sh` that the `gb200` and `vr200`
performance profiles carry. `rke2` therefore ships no `[script]` and does the grub work
as a package lifecycle step, which is also the pattern `configure_pcie_acs.sh` and
`configure_iommu_passthrough.sh` already use for grub drop-ins.

### New modes

| Script | Mode | Does |
|---|---|---|
| `configure_bootloader.sh` | `config` (last) | Writes `/etc/default/grub.d/99-nvidia-tuned-cmdline.cfg`, regenerates grub |
| `configure_bootloader_check.sh` | `config-check` (last) | Evaluates the drop-in the way grub will and compares it to `/etc/tuned/bootcmdline` |
| `post_interrupt_bootloader_check.sh` | `post-interrupt-check` | Asserts every argument is live in `/proc/cmdline` |
| `uninstall_bootloader.sh` / `_check.sh` | `uninstall` | Removes the drop-in and regenerates grub |

`configure-bootloader` runs last in `config` because `/etc/tuned/bootcmdline` only exists
once tuned has activated the profile.

The post-interrupt check is the one worth having: grub quietly failing to pick the
drop-in up is invisible from the config stage, so without it a node comes up reporting
success while running none of the tuning it was selected for.

### Safety around the existing services

Everything is gated on `profiles/service/{service}/bootloader.enabled`, so `eks`, `aks`,
`bcm` and `oci` are no-ops. Two further precautions, because this step runs *after* the
profile is applied and so after `eks`/`aks` have written their own grub.d file:

- The drop-in has its own filename rather than the `99_tuned.cfg` those profiles write.
- Both the stand-down removal and the uninstall removal are scoped to a marker line this
  step writes, so neither can delete a file another service owns.

It also appends to `GRUB_CMDLINE_LINUX_DEFAULT` rather than replacing it (what the
`eks`/`aks` script does), so a bare-metal host keeps the serial console arguments an
operator needs to reach a node that fails to boot.

### Notes for reviewers

- `package_version` 0.9.0. `CHANGELOG.md` untouched; behavior notes are in
  `RELEASE_NOTES.md`.
- No `.github/` changes: those track packages, and this adds a service to an existing one.
- The README's stale `Package Version: 0.7.1` line is corrected to 0.9.0, and `vr200` is
  added to the accelerators table where it was missing.

### Out of scope, found while working

`service=eks` with `accelerator=gb200` hits the `[script]` collision described above
today, silently dropping `containerd_service.sh` and its containerd `LimitSTACK` setting.
Left for a separate PR.

## Checklist
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nodewright-packages/blob/HEAD/CONTRIBUTING.md).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
