### PR TITLE
fix(general/ci): wait for provenance attestation before signing

### DIFF
--- a/.github/actions/build-package/action.yml
+++ b/.github/actions/build-package/action.yml
@@ -159,6 +159,60 @@ runs:
         # attestation pushed to the registry, not a storage record.
         create-storage-record: false
 
+    # actions/attest-build-provenance above and cosign sign below both attach
+    # to the same OCI referrers fallback tag (sha256-<digest>), because GHCR
+    # does not implement the referrers API. Each attach is a read-modify-write
+    # of that tag, so when cosign reads it before the attestation is visible it
+    # rewrites the index with only its own signature and the provenance
+    # referrer is dropped (this is what failed the nvidia-tuned/0.9.0 release
+    # build). Block until the attestation reads back, so cosign appends to the
+    # index instead of replacing it.
+    - name: Wait for provenance attestation to be readable
+      if: inputs.generate_attestation == 'true' && inputs.sign_image == 'true' && inputs.push == 'true'
+      shell: bash
+      env:
+        REGISTRY: ${{ inputs.registry }}
+        REPOSITORY: ${{ inputs.image_name }}/${{ inputs.package_name }}
+        DIGEST: ${{ steps.push.outputs.digest }}
+        REGISTRY_TOKEN: ${{ inputs.github_token }}
+      run: |
+        set -euo pipefail
+
+        # OCI repository names must be lowercase; image_name carries the
+        # uppercase org from github.repository (NVIDIA/...).
+        repository="${REPOSITORY,,}"
+        fallback_tag="sha256-${DIGEST#sha256:}"
+        manifest_url="https://${REGISTRY}/v2/${repository}/manifests/${fallback_tag}"
+
+        # Standard registry token exchange: the unauthenticated request answers
+        # with the realm and service to ask a pull token for.
+        challenge="$(curl -sSI "${manifest_url}" | grep -i '^www-authenticate:' || true)"
+        token=""
+        if [[ -n "${challenge}" ]]; then
+          realm="$(sed -n 's/.*realm="\([^"]*\)".*/\1/p' <<<"${challenge}")"
+          service="$(sed -n 's/.*service="\([^"]*\)".*/\1/p' <<<"${challenge}")"
+          token="$(curl -sS -u "${GITHUB_ACTOR}:${REGISTRY_TOKEN}" --get \
+            --data-urlencode "service=${service}" \
+            --data-urlencode "scope=repository:${repository}:pull" \
+            "${realm}" | jq -r '.token // .access_token // empty')"
+        fi
+
+        for attempt in $(seq 1 30); do
+          if curl -sS -H "Authorization: Bearer ${token}" \
+              -H 'Accept: application/vnd.oci.image.index.v1+json' \
+              "${manifest_url}" \
+            | jq -e '[.manifests[]?.annotations."dev.sigstore.bundle.predicateType"]
+                     | index("https://slsa.dev/provenance/v1")' > /dev/null 2>&1; then
+            echo "Provenance referrer visible on ${fallback_tag} after ${attempt} attempt(s)."
+            exit 0
+          fi
+          sleep 2
+        done
+
+        echo "ERROR: the provenance attestation for ${DIGEST} was not readable from ${REGISTRY}/${repository} after 60s." >&2
+        echo "Signing now would drop it from the referrers index, so failing instead." >&2
+        exit 1
+
     - name: Install cosign
       if: inputs.sign_image == 'true'
       uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6  # v4.1.2


### PR DESCRIPTION
## Problem

The `nvidia-tuned/0.9.0` tag build failed on its last step ([run 33801897039](https://github.com/NVIDIA/nodewright-packages/actions/runs/33801897039/job/100803145101)):

```text
Error: none of the attestations matched the predicate type: https://slsa.dev/provenance/v1,
found: https://sigstore.dev/cosign/sign/v1
```

The build, push, and signature were all fine. The SLSA provenance attestation was missing from the registry.

## Root cause

GHCR does not implement the OCI referrers API (`/v2/.../referrers/<digest>` returns `MANIFEST_UNKNOWN`), so everything attached to an image lives in one index under the fallback tag `sha256-<digest>`. Two steps in `.github/actions/build-package/action.yml` write that same tag seconds apart, and each does a read-modify-write:

1. `actions/attest-build-provenance` with `push-to-registry: true` (logged "Attestation uploaded to registry" at 20:24:07)
2. `cosign sign`, which since cosign v3 defaults to `--new-bundle-format=true` and therefore stores the signature as a referrer rather than a `.sig` tag (bundle stamped 20:24:12)

cosign's read of the fallback tag did not reflect the attestation written five seconds earlier, so it wrote a fresh index containing only its own signature and dropped the provenance referrer.

Supporting evidence:

- The fallback tag for the failed digest held exactly one referrer, the cosign signature; the provenance was gone even though the attest step reported success (GitHub-side record `attestations/45093337` still exists).
- Eight prior releases (`tuning:1.1.7`, `tuned:1.3.2`, `kdump:1.1.1`, `nvidia-setup:0.6.0`, `nvidia-tuned:0.7.1/0.7.2/0.8.0`, `bind-mount:0.1.1`) all carry both referrers, so the two writers normally interleave correctly.
- The passing run the day before used the same pinned action SHAs and the same cosign v3.0.6, with the same roughly five second gap. Nothing in the tooling changed; the read just came back stale this time.
- The repo has zero `.sig` and zero `.att` tags against 56 `sha256-*` fallback tags, confirming both artifacts share one tag namespace.

## Fix

Poll the fallback tag between the attest step and the sign step until the provenance referrer reads back, for up to 60s, so cosign appends to the existing index instead of replacing it. If it never becomes visible the build fails rather than publishing an image whose provenance is about to be dropped.

The step only runs when the job both attests and signs and is pushing, so PR builds are unaffected.

## Testing

- YAML parses and the step's inline bash passes `bash -n` and `shellcheck` (only an SC2153 false positive for the env-provided `REPOSITORY`).
- Ran the extracted script against real GHCR data: it exits 0 on the first attempt for `tuning:1.1.7`, which has the provenance referrer, and exits 1 with the timeout error for a digest that has none. Uppercase-org lowercasing was exercised in both.
- `nvidia-tuned/0.9.0` was unblocked separately by re-running the job; that build now carries both referrers again.

## Known alternative

A stricter fix would take the two writers off the shared tag entirely by signing with `--new-bundle-format=false`, which restores the legacy `sha256-<digest>.sig` attachment tag. That removes the race by construction, but it changes the published signature format and would require `--new-bundle-format=false` on every `cosign verify` call, including consumers'. The readback wait keeps the current format and turns a silent clobber into a hard failure.
